### PR TITLE
chore: 稳定化原项目并对齐文档默认值

### DIFF
--- a/HANDOVER_REQUIREMENTS_AND_FLOW.md
+++ b/HANDOVER_REQUIREMENTS_AND_FLOW.md
@@ -1,11 +1,11 @@
-# Crawlee + Camoufox 需求沉淀与函数地图（可复用交接稿）
+﻿# Crawlee + Camoufox 需求沉淀与函数地图（可复用交接稿）
 
 ## 1. 任务目标（到目前为止）
 - 目标站点：`ly.com`
-- 目标检索：`北京(BJS) -> 三亚(SYX)`，日期 `2026-04-01`，航班号 `CA1345`
-- 输出频率：每 `5` 分钟给一个价格结果
+- 目标检索：`北京(BJS) -> 三亚(SYX)`，日期 `2026-04-01`，航班号默认 `CZ6714`
+- 输出频率：每 `5` 分钟产出一条结果
 - 运行方式：常驻 Web 服务
-- 可视要求：抓取时可看到浏览器窗口（可配置）
+- 默认运行模式：无头（`headless: true`，可配置）
 
 ## 2. 必须具备的能力
 - 使用 Crawlee 管理抓取任务与长跑循环
@@ -16,20 +16,20 @@
 - 提供查询接口（最新结果、历史、手动触发、SSE 推送）
 
 ## 3. 关键经验与约束（对话中确认）
-- 站点数据可能懒加载，`CA1345` 可能出现在列表底部（“最后一行”）
+- 站点数据可能懒加载，目标航班可能出现在列表底部
 - 仅靠 `page.content()` 容易漏航班，需优先读可见文本并滚动加载
 - 窗口不在最前时，`mouse.wheel` 可能不稳定，改为页面内 `window.scrollTo`
-- 配置不要散落在代码里，要集中在一个配置文件（`src/config.js`）
-- 源码注释要中文，便于快速维护
+- 配置集中在 `src/config.js`，避免在业务代码写死
+- 源码注释尽量用中文，方便维护
 
 ## 4. 当前代码结构
-- 统一配置入口：[src/config.js](/F:/lake/myCrawleeEngineer/src/config.js)
-- 主程序入口：[src/server.js](/F:/lake/myCrawleeEngineer/src/server.js)
-- 项目说明：[README.md](/F:/lake/myCrawleeEngineer/README.md)
+- 统一配置入口：`src/config.js`
+- 主程序入口：`src/server.js`
+- 项目说明：`README.md`
 - 结果输出：`output/flight-price-results.ndjson`
 
 ## 5. 配置清单（改哪里）
-配置都在 [src/config.js](/F:/lake/myCrawleeEngineer/src/config.js)：
+配置都在 `src/config.js`：
 - `server`：端口
 - `task`：日期、出发地、到达地、航班号、轮询间隔
 - `browser`：是否无头、可视停留、Camoufox 参数
@@ -41,16 +41,16 @@
 - `timeouts`：导航与 networkidle 超时
 - `api`：`/history` 默认与最大限制
 
-### 推荐基线配置（按本次需求）
+### 推荐基线配置（当前默认）
 - `task.flightDate = "2026-04-01"`
 - `task.departure = "BJS"`
 - `task.arrival = "SYX"`
-- `task.flightNo = "CA1345"`
+- `task.flightNo = "CZ6714"`
 - `task.pollIntervalMinutes = 5`
-- `browser.headless = false`（需要可视窗口时）
+- `browser.headless = true`（需要可视窗口时改为 `false`）
 
 ## 6. 函数位置与作用（快速地图）
-函数都在 [src/server.js](/F:/lake/myCrawleeEngineer/src/server.js)：
+函数都在 `src/server.js`：
 
 | 位置 | 函数/对象 | 作用 |
 |---|---|---|
@@ -84,7 +84,7 @@
 ## 8. 验收标准（建议）
 - 服务启动后可访问 `/health`
 - 轮询周期符合配置（默认 5 分钟）
-- `CA1345` 能在底部懒加载场景被识别
+- 目标航班能在底部懒加载场景被识别
 - 浏览器前后台切换时，抓取稳定性不明显下降
 - 结果持续落盘且 SSE 能实时收到更新
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - Camoufox（隐形 Firefox）
 - Web Server 持续运行（Express）
 
-默认任务（可在配置文件改）：查询 `2026-04-01` 北京(`BJS`) -> 三亚(`SYX`) 航班 `CA1345`，每 5 分钟执行一次。
+默认任务（可在配置文件改）：查询 `2026-04-01` 北京(`BJS`) -> 三亚(`SYX`) 航班 `CZ6714`，每 5 分钟执行一次。
 
 ## 安装
 
@@ -28,8 +28,8 @@ npm install
 npm start
 ```
 
-默认是可视模式（`headless: false`），抓取时会弹出浏览器窗口。  
-可在 `src/config.js -> browser.visibleHoldMs` 调整停留时长（毫秒）。
+默认是无头模式（`headless: true`）。  
+如需可视化观察抓取过程，可将 `src/config.js -> browser.headless` 改为 `false`，并通过 `browser.visibleHoldMs` 调整停留时长（毫秒）。
 
 ## API
 
@@ -53,4 +53,4 @@ npm start
 - `redirectedFromExpectedDate`
 - `finalDate`
 
-如果页面中找不到 `CA1345`，会返回 `status = flight-not-found`。
+如果页面中找不到配置中的目标航班号（默认 `CZ6714`），会返回 `status = flight-not-found`。

--- a/src/server.js
+++ b/src/server.js
@@ -128,7 +128,7 @@ function extractPriceFromVisibleText(pageText, flightNo) {
     };
 }
 
-// 滚动采集页面可见文本，尽量覆盖底部懒加载航班（如 CA1345 在最后一行）。
+// 滚动采集页面可见文本，尽量覆盖底部懒加载航班（例如目标航班在最后一行）。
 async function collectPageTextWithScroll(page, flightNo) {
     const target = flightNo.toUpperCase();
     let longestText = '';
@@ -336,7 +336,10 @@ async function runSingleCheck(context) {
         // 双通道提取：先可见文本（主）再 HTML（兜底）。
         const extractedFromVisibleText = extractPriceFromVisibleText(pageText, FLIGHT_NO);
         const extractedFromHtml = extractPriceByFlightNo(html, FLIGHT_NO);
-        const extracted = extractedFromVisibleText ?? extractedFromHtml;
+        // 可见文本命中但 price 为空时，继续尝试 HTML 兜底；若仍失败，再回退到可见文本结果。
+        const extracted = extractedFromVisibleText?.price != null
+            ? extractedFromVisibleText
+            : extractedFromHtml ?? extractedFromVisibleText;
         const flightFound = Boolean(extracted);
         const hasPrice = extracted?.price != null;
         const finalUrl = page.url();
@@ -431,96 +434,111 @@ async function startMonitor() {
         return;
     }
 
-    monitorStarted = true;
+    try {
+        await mkdir(OUTPUT_DIR, { recursive: true });
 
-    await mkdir(OUTPUT_DIR, { recursive: true });
-
-    if (CAMOUFOX_AUTO_FETCH) {
-        try {
-            log.info('Checking Camoufox browser binaries...');
-            await downloadBrowser();
-        } catch (error) {
-            log.warning(`Camoufox binary prefetch failed: ${error.message}`);
-        }
-    }
-
-    proxyConfiguration = PROXY_URLS.length
-        ? new ProxyConfiguration({ proxyUrls: PROXY_URLS })
-        : null;
-
-    requestQueue = await RequestQueue.open(config.crawler.requestQueueName);
-
-    crawler = new BasicCrawler({
-        requestQueue,
-        // keepAlive=true 表示队列空了也不退出，适合长跑服务。
-        keepAlive: config.crawler.keepAlive,
-        // 并发由配置文件控制。
-        maxConcurrency: config.crawler.maxConcurrency,
-        minConcurrency: config.crawler.minConcurrency,
-        // 请求级别重试次数（不含 session 轮换带来的重试）。
-        maxRequestRetries: config.crawler.maxRequestRetries,
-        // 同一请求最多可触发的 session 轮换次数。
-        maxSessionRotations: config.crawler.maxSessionRotations,
-        retryOnBlocked: config.crawler.retryOnBlocked,
-        // 开启会话池（cookies + 失败分数 + 退休机制）。
-        useSessionPool: config.crawler.useSessionPool,
-        sessionPoolOptions: config.crawler.sessionPoolOptions,
-        requestHandlerTimeoutSecs: config.crawler.requestHandlerTimeoutSecs,
-        async requestHandler(context) {
-            inFlight += 1;
+        if (CAMOUFOX_AUTO_FETCH) {
             try {
-                await runSingleCheck(context);
-            } finally {
-                inFlight = Math.max(0, inFlight - 1);
+                log.info('Checking Camoufox browser binaries...');
+                await downloadBrowser();
+            } catch (error) {
+                log.warning(`Camoufox binary prefetch failed: ${error.message}`);
             }
-        },
-        async failedRequestHandler({ request, session }, error) {
-            // 最终失败也写入结果，避免“静默失败”。
-            const fallbackResult = {
-                timestamp: new Date().toISOString(),
-                task: {
-                    site: 'ly.com',
-                    departure: DEPARTURE,
-                    arrival: ARRIVAL,
-                    expectedDate: FLIGHT_DATE,
-                    flightNo: FLIGHT_NO,
-                },
-                status: 'failed',
-                foundFlight: false,
-                price: null,
-                priceCurrency: 'CNY',
-                extractionMethod: null,
-                extractionSnippet: null,
-                requestUrl: request.url,
-                finalUrl: null,
-                finalDate: null,
-                redirectedFromExpectedDate: false,
-                proxyUrl: null,
-                sessionId: session?.id ?? null,
-                durationMs: null,
-                triggerReason: request.userData.triggerReason,
-                note: `抓取失败: ${error.message}`,
-            };
+        }
 
-            await persistAndBroadcast(fallbackResult);
-        },
-    });
+        proxyConfiguration = PROXY_URLS.length
+            ? new ProxyConfiguration({ proxyUrls: PROXY_URLS })
+            : null;
 
-    // 启动 crawler 主循环（常驻）。
-    crawlerPromise = crawler.run().catch((error) => {
-        log.exception(error, 'Crawler loop crashed unexpectedly.');
-    });
+        requestQueue = await RequestQueue.open(config.crawler.requestQueueName);
 
-    // 启动后先抓一轮，再进入定时抓取。
-    await enqueueCheck('startup');
+        crawler = new BasicCrawler({
+            requestQueue,
+            // keepAlive=true 表示队列空了也不退出，适合长跑服务。
+            keepAlive: config.crawler.keepAlive,
+            // 并发由配置文件控制。
+            maxConcurrency: config.crawler.maxConcurrency,
+            minConcurrency: config.crawler.minConcurrency,
+            // 请求级别重试次数（不含 session 轮换带来的重试）。
+            maxRequestRetries: config.crawler.maxRequestRetries,
+            // 同一请求最多可触发的 session 轮换次数。
+            maxSessionRotations: config.crawler.maxSessionRotations,
+            retryOnBlocked: config.crawler.retryOnBlocked,
+            // 开启会话池（cookies + 失败分数 + 退休机制）。
+            useSessionPool: config.crawler.useSessionPool,
+            sessionPoolOptions: config.crawler.sessionPoolOptions,
+            requestHandlerTimeoutSecs: config.crawler.requestHandlerTimeoutSecs,
+            async requestHandler(context) {
+                inFlight += 1;
+                try {
+                    await runSingleCheck(context);
+                } finally {
+                    inFlight = Math.max(0, inFlight - 1);
+                }
+            },
+            async failedRequestHandler({ request, session }, error) {
+                // 最终失败也写入结果，避免“静默失败”。
+                const fallbackResult = {
+                    timestamp: new Date().toISOString(),
+                    task: {
+                        site: 'ly.com',
+                        departure: DEPARTURE,
+                        arrival: ARRIVAL,
+                        expectedDate: FLIGHT_DATE,
+                        flightNo: FLIGHT_NO,
+                    },
+                    status: 'failed',
+                    foundFlight: false,
+                    price: null,
+                    priceCurrency: 'CNY',
+                    extractionMethod: null,
+                    extractionSnippet: null,
+                    requestUrl: request.url,
+                    finalUrl: null,
+                    finalDate: null,
+                    redirectedFromExpectedDate: false,
+                    proxyUrl: null,
+                    sessionId: session?.id ?? null,
+                    durationMs: null,
+                    triggerReason: request.userData.triggerReason,
+                    note: `抓取失败: ${error.message}`,
+                };
 
-    enqueueTimer = setInterval(() => {
-        void enqueueCheck('scheduled-5min').catch((error) => {
-            log.warning(`enqueue failed: ${error.message}`);
+                await persistAndBroadcast(fallbackResult);
+            },
         });
-    }, POLL_INTERVAL_MS);
 
-    log.info(`Monitor started. Poll interval: ${Math.round(POLL_INTERVAL_MS / 1000)}s`);
+        // 启动 crawler 主循环（常驻）。
+        crawlerPromise = crawler.run().catch((error) => {
+            log.exception(error, 'Crawler loop crashed unexpectedly.');
+        });
+
+        // 启动后先抓一轮，再进入定时抓取。
+        await enqueueCheck('startup');
+
+        const scheduledTriggerReason = `scheduled-${POLL_INTERVAL_MINUTES}min`;
+        enqueueTimer = setInterval(() => {
+            void enqueueCheck(scheduledTriggerReason).catch((error) => {
+                log.warning(`enqueue failed: ${error.message}`);
+            });
+        }, POLL_INTERVAL_MS);
+
+        monitorStarted = true;
+        log.info(`Monitor started. Poll interval: ${Math.round(POLL_INTERVAL_MS / 1000)}s`);
+    } catch (error) {
+        monitorStarted = false;
+        if (enqueueTimer) {
+            clearInterval(enqueueTimer);
+            enqueueTimer = undefined;
+        }
+        if (crawler) {
+            await crawler.stop().catch(() => {});
+        }
+        requestQueue = undefined;
+        crawler = undefined;
+        crawlerPromise = undefined;
+        throw error;
+    }
 }
 
 // 优雅停止：先停定时器，再停 crawler。
@@ -534,6 +552,8 @@ async function stopMonitor() {
         await crawler.stop().catch(() => {});
         await crawlerPromise;
     }
+
+    monitorStarted = false;
 }
 
 const app = express();
@@ -569,10 +589,11 @@ app.get('/latest', (_req, res) => {
 
 // 历史结果（内存），可通过 ?limit=xx 控制返回数量。
 app.get('/history', (req, res) => {
-    const limit = Math.max(
-        1,
-        Math.min(config.api.historyMaxLimit, parseInt(req.query.limit ?? String(config.api.historyDefaultLimit), 10)),
-    );
+    const parsedLimit = Number.parseInt(String(req.query.limit ?? config.api.historyDefaultLimit), 10);
+    const normalizedLimit = Number.isFinite(parsedLimit)
+        ? parsedLimit
+        : config.api.historyDefaultLimit;
+    const limit = Math.max(1, Math.min(config.api.historyMaxLimit, normalizedLimit));
     res.json({
         count: Math.min(limit, history.length),
         items: history.slice(-limit),


### PR DESCRIPTION
## 背景
按“先迁移后整备”计划，在 `AlamoScouts` 上对原项目做最小修复与跑通验证，不做大重构。

## 本次改动
1. 修复 `/history` 在 `limit` 非数字时返回 `count:null` 的问题。
2. 修复价格提取链路：可见文本命中但 price 为空时，继续走 HTML 兜底。
3. 修复定时触发原因写死为 `scheduled-5min`，改为按配置动态生成。
4. 修复启动状态标记时机，避免初始化异常时 `monitorStarted` 状态失真。
5. 同步 README 与交接文档，确保默认值与当前配置一致，清理旧仓路径引用。

## 验证
- `npm install`
- `node --check src/server.js`
- `npm start` 后验证：`/health` `/latest` `/history` `/trigger` `/stream`
- 复测 `GET /history?limit=abc` 返回 `count` 为数字类型。

Fixes #3
Fixes #4
Fixes #5
Fixes #6
Fixes #7