### PR TITLE
feat(proxyhub): #24 10h连续压测调参与IP价值评估

### DIFF
--- a/apps/proxy-pool-service/src/config.js
+++ b/apps/proxy-pool-service/src/config.js
@@ -112,12 +112,32 @@
             riskyWarrior: 20,
             thousandService: 1000,
         },
+        valueModel: {
+            combatPointCap: 1200,
+            honorActiveWeight: 30,
+            honorHistoryWeight: 10,
+            weights: {
+                rank: 16,
+                combat: 24,
+                health: 16,
+                discipline: 14,
+                successRatio: 12,
+                battleRatio: 10,
+                honor: 8,
+            },
+            lifecycleScoreMap: {
+                active: 100,
+                reserve: 72,
+                candidate: 58,
+                retired: 8,
+            },
+        },
     },
     ui: {
         refreshMs: 5_000,
     },
     soak: {
-        durationHours: 24,
+        durationHours: 10,
         summaryIntervalMs: 3_600_000,
     },
 };

--- a/apps/proxy-pool-service/src/config.test.js
+++ b/apps/proxy-pool-service/src/config.test.js
@@ -23,4 +23,7 @@ test('config ranks should be ordered and complete', () => {
     const ranks = config.policy.ranks.map((item) => item.rank);
     assert.deepEqual(ranks, ['新兵', '列兵', '士官', '尉官', '王牌']);
     assert.equal(config.policy.promotionProtectHours, 6);
+    assert.equal(config.policy.valueModel.combatPointCap, 1200);
+    assert.equal(config.policy.valueModel.lifecycleScoreMap.retired, 8);
+    assert.equal(config.soak.durationHours, 10);
 });

--- a/apps/proxy-pool-service/src/db.js
+++ b/apps/proxy-pool-service/src/db.js
@@ -18,6 +18,17 @@ function parseJsonArray(raw) {
     }
 }
 
+// 0196_parseJsonObject_解析JSON对象逻辑
+function parseJsonObject(raw) {
+    try {
+        if (!raw) return {};
+        const parsed = JSON.parse(raw);
+        return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+    } catch {
+        return {};
+    }
+}
+
 class ProxyHubDb {
     // 0001_constructor_初始化实例逻辑
     constructor(config) {
@@ -70,6 +81,8 @@ class ProxyHubDb {
                 last_battle_outcome TEXT,
                 battle_success_count INTEGER NOT NULL DEFAULT 0,
                 battle_fail_count INTEGER NOT NULL DEFAULT 0,
+                ip_value_score REAL NOT NULL DEFAULT 0,
+                ip_value_breakdown_json TEXT NOT NULL DEFAULT '{}',
                 retired_type TEXT,
                 promotion_protect_until TEXT,
                 recent_window_json TEXT NOT NULL DEFAULT '[]',
@@ -244,6 +257,8 @@ class ProxyHubDb {
             { name: 'last_battle_outcome', sql: 'TEXT' },
             { name: 'battle_success_count', sql: 'INTEGER NOT NULL DEFAULT 0' },
             { name: 'battle_fail_count', sql: 'INTEGER NOT NULL DEFAULT 0' },
+            { name: 'ip_value_score', sql: 'REAL NOT NULL DEFAULT 0' },
+            { name: 'ip_value_breakdown_json', sql: "TEXT NOT NULL DEFAULT '{}'" },
         ];
 
         for (const column of requiredColumns) {
@@ -578,7 +593,8 @@ class ProxyHubDb {
                 success_count, block_count, timeout_count, network_error_count,
                 total_samples, retired_type, is_applied, updated_at, last_checked_at,
                 last_validation_at, last_validation_ok, last_validation_reason, last_validation_latency_ms,
-                last_battle_checked_at, last_battle_outcome, battle_success_count, battle_fail_count
+                last_battle_checked_at, last_battle_outcome, battle_success_count, battle_fail_count,
+                ip_value_score, ip_value_breakdown_json
             FROM proxies
             ${where}
             ORDER BY updated_at DESC
@@ -591,7 +607,8 @@ class ProxyHubDb {
         return this.db.prepare(`
             SELECT rank, COUNT(*) AS count,
                 ROUND(AVG(health_score), 2) AS avgHealth,
-                ROUND(AVG(combat_points), 2) AS avgCombat
+                ROUND(AVG(combat_points), 2) AS avgCombat,
+                ROUND(AVG(ip_value_score), 2) AS avgValue
             FROM proxies
             GROUP BY rank
             ORDER BY CASE rank
@@ -602,6 +619,45 @@ class ProxyHubDb {
                 WHEN '王牌' THEN 5
                 ELSE 6 END
         `).all();
+    }
+
+    // 0197_getValueBoard_获取价值榜逻辑
+    getValueBoard(limit = 100, lifecycle) {
+        const safeLimit = Math.max(1, Math.min(500, Number(limit) || 100));
+        const clauses = [];
+        const params = { limit: safeLimit };
+        if (lifecycle) {
+            clauses.push('lifecycle = @lifecycle');
+            params.lifecycle = String(lifecycle);
+        }
+
+        const where = clauses.length ? `WHERE ${clauses.join(' AND ')}` : '';
+        const rows = this.db.prepare(`
+            SELECT id, display_name, ip, port, protocol, source, lifecycle, rank,
+                ip_value_score, ip_value_breakdown_json,
+                combat_points, health_score, discipline_score,
+                success_count, total_samples, battle_success_count, battle_fail_count,
+                honor_active_json, retired_type, updated_at
+            FROM proxies
+            ${where}
+            ORDER BY ip_value_score DESC, combat_points DESC, updated_at DESC
+            LIMIT @limit
+        `).all(params);
+
+        return rows.map((row) => {
+            const battleTotal = (row.battle_success_count || 0) + (row.battle_fail_count || 0);
+            return {
+                ...row,
+                ip_value_breakdown: parseJsonObject(row.ip_value_breakdown_json),
+                honor_active: parseJsonArray(row.honor_active_json),
+                success_ratio: row.total_samples > 0
+                    ? Number((row.success_count / row.total_samples).toFixed(4))
+                    : 0,
+                battle_ratio: battleTotal > 0
+                    ? Number((row.battle_success_count / battleTotal).toFixed(4))
+                    : 0,
+            };
+        });
     }
 
     // 0188_getHonors_获取荣誉逻辑

--- a/apps/proxy-pool-service/src/db.test.js
+++ b/apps/proxy-pool-service/src/db.test.js
@@ -259,6 +259,7 @@ test('query list APIs should support filters and distributions', () => {
     assert.equal(Object.prototype.hasOwnProperty.call(all[0], 'last_battle_outcome'), true);
     assert.equal(Object.prototype.hasOwnProperty.call(all[0], 'battle_success_count'), true);
     assert.equal(Object.prototype.hasOwnProperty.call(all[0], 'last_validation_ok'), true);
+    assert.equal(Object.prototype.hasOwnProperty.call(all[0], 'ip_value_score'), true);
 
     h.db.updateProxyById(all[0].id, { rank: '士官', lifecycle: 'active', updated_at: now });
 
@@ -268,6 +269,79 @@ test('query list APIs should support filters and distributions', () => {
     assert.equal(h.db.getSourceDistribution().length, 1);
     assert.equal(h.db.getLifecycleDistribution().length >= 1, true);
     assert.equal(h.db.getRankBoard().length >= 1, true);
+
+    cleanup(h);
+});
+
+test('value board API should sort by value and parse breakdown and honor fields', () => {
+    const h = createDb();
+    const now = new Date().toISOString();
+
+    h.db.upsertSourceBatch(
+        [
+            { ip: '6.6.6.1', port: 80, protocol: 'http' },
+            { ip: '6.6.6.2', port: 80, protocol: 'http' },
+        ],
+        (() => {
+            let i = 0;
+            return () => `价值-${++i}`;
+        })(),
+        'src-value',
+        'batch-value',
+        now,
+    );
+
+    const all = h.db.getProxyList({ limit: 10 });
+    h.db.updateProxyById(all[0].id, {
+        lifecycle: 'active',
+        ip_value_score: 88.3,
+        ip_value_breakdown_json: JSON.stringify({ grade: 'A' }),
+        honor_active_json: JSON.stringify(['钢铁连胜']),
+        success_count: 8,
+        total_samples: 10,
+        battle_success_count: 3,
+        battle_fail_count: 1,
+        updated_at: now,
+    });
+    h.db.updateProxyById(all[1].id, {
+        lifecycle: 'reserve',
+        ip_value_score: 40,
+        ip_value_breakdown_json: '[]',
+        honor_active_json: '',
+        updated_at: now,
+    });
+
+    const board = h.db.getValueBoard(10);
+    assert.equal(board.length, 2);
+    assert.equal(board[0].ip_value_score >= board[1].ip_value_score, true);
+    assert.equal(board[0].ip_value_breakdown.grade, 'A');
+    assert.deepEqual(board[1].ip_value_breakdown, {});
+    assert.deepEqual(board[1].honor_active, []);
+    assert.equal(board[0].success_ratio, 0.8);
+    assert.equal(board[0].battle_ratio, 0.75);
+
+    const filtered = h.db.getValueBoard(10, 'active');
+    assert.equal(filtered.length, 1);
+    assert.equal(filtered[0].lifecycle, 'active');
+
+    h.db.updateProxyById(all[1].id, {
+        ip_value_breakdown_json: '',
+        updated_at: now,
+    });
+    const emptyBreakdown = h.db.getValueBoard(10);
+    assert.deepEqual(emptyBreakdown[1].ip_value_breakdown, {});
+
+    h.db.updateProxyById(all[1].id, {
+        ip_value_breakdown_json: '{bad',
+        updated_at: now,
+    });
+    const badBreakdown = h.db.getValueBoard(10);
+    assert.deepEqual(badBreakdown[1].ip_value_breakdown, {});
+
+    const fallbackLimit = h.db.getValueBoard('bad');
+    assert.equal(fallbackLimit.length >= 1, true);
+    const clampedLimit = h.db.getValueBoard(0);
+    assert.equal(clampedLimit.length >= 1, true);
 
     cleanup(h);
 });

--- a/apps/proxy-pool-service/src/policy.js
+++ b/apps/proxy-pool-service/src/policy.js
@@ -1,0 +1,165 @@
+// 0221_isPlainObject_判断普通对象逻辑
+function isPlainObject(value) {
+    return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+// 0222_cloneJson_克隆JSON逻辑
+function cloneJson(value) {
+    return JSON.parse(JSON.stringify(value));
+}
+
+// 0223_mergeObjects_合并对象逻辑
+function mergeObjects(base, patch) {
+    if (!isPlainObject(base)) return cloneJson(patch);
+    const result = { ...base };
+    for (const [key, value] of Object.entries(patch)) {
+        if (Array.isArray(value)) {
+            result[key] = cloneJson(value);
+            continue;
+        }
+        if (isPlainObject(value) && isPlainObject(result[key])) {
+            result[key] = mergeObjects(result[key], value);
+            continue;
+        }
+        result[key] = value;
+    }
+    return result;
+}
+
+const ALLOWED_KEYS = new Set([
+    'serviceHourScale',
+    'promotionProtectHours',
+    'ranks',
+    'scoring',
+    'demotion',
+    'retirement',
+    'honors',
+    'valueModel',
+]);
+
+// 0224_normalizePolicyPatch_规范化策略补丁逻辑
+function normalizePolicyPatch(rawPatch) {
+    if (!isPlainObject(rawPatch)) {
+        return { ok: false, error: 'invalid-policy-patch' };
+    }
+    const patch = rawPatch.policy && isPlainObject(rawPatch.policy) ? rawPatch.policy : rawPatch;
+    for (const key of Object.keys(patch)) {
+        if (!ALLOWED_KEYS.has(key)) {
+            return { ok: false, error: `unsupported-policy-field:${key}` };
+        }
+    }
+    return { ok: true, patch };
+}
+
+// 0225_applyPolicyPatch_应用策略补丁逻辑
+function applyPolicyPatch(currentPolicy, patch) {
+    return mergeObjects(currentPolicy, patch);
+}
+
+// 0226_toFinite_转换有限数字逻辑
+function toFinite(value) {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : null;
+}
+
+// 0227_validateRanks_验证军衔逻辑
+function validateRanks(ranks) {
+    if (!Array.isArray(ranks) || ranks.length === 0) {
+        return 'ranks-empty';
+    }
+
+    let prev = null;
+    for (const item of ranks) {
+        if (!isPlainObject(item) || typeof item.rank !== 'string' || item.rank.trim() === '') {
+            return 'rank-item-invalid';
+        }
+        const minHours = toFinite(item.minHours);
+        const minPoints = toFinite(item.minPoints);
+        const minSamples = toFinite(item.minSamples);
+        if (minHours == null || minPoints == null || minSamples == null) {
+            return 'rank-threshold-invalid';
+        }
+        if (minHours < 0 || minPoints < 0 || minSamples < 0) {
+            return 'rank-threshold-negative';
+        }
+
+        if (prev && (minHours < prev.minHours || minPoints < prev.minPoints || minSamples < prev.minSamples)) {
+            return 'rank-threshold-not-ascending';
+        }
+
+        prev = { minHours, minPoints, minSamples };
+    }
+    return null;
+}
+
+// 0228_validatePolicy_验证策略逻辑
+function validatePolicy(policy) {
+    if (!isPlainObject(policy)) {
+        return { ok: false, error: 'policy-invalid' };
+    }
+
+    const serviceHourScale = toFinite(policy.serviceHourScale);
+    if (serviceHourScale == null || serviceHourScale <= 0) {
+        return { ok: false, error: 'serviceHourScale-invalid' };
+    }
+
+    const promotionProtectHours = toFinite(policy.promotionProtectHours);
+    if (promotionProtectHours == null || promotionProtectHours < 0) {
+        return { ok: false, error: 'promotionProtectHours-invalid' };
+    }
+
+    const rankError = validateRanks(policy.ranks);
+    if (rankError) {
+        return { ok: false, error: rankError };
+    }
+
+    const ratioFields = [
+        policy.demotion?.regularBlockedRatio,
+        policy.demotion?.severeBlockedRatio,
+        policy.retirement?.technicalSuccessRatio,
+        policy.retirement?.battleDamageBlockedRatio,
+    ];
+    for (const value of ratioFields) {
+        const num = toFinite(value);
+        if (num == null || num < 0 || num > 1) {
+            return { ok: false, error: 'ratio-invalid' };
+        }
+    }
+
+    const honors = policy.honors || {};
+    for (const key of ['steelStreak', 'riskyWarrior', 'thousandService']) {
+        const num = toFinite(honors[key]);
+        if (num == null || num <= 0) {
+            return { ok: false, error: `honors-${key}-invalid` };
+        }
+    }
+
+    const valueModel = policy.valueModel || {};
+    if (Object.prototype.hasOwnProperty.call(valueModel, 'combatPointCap')) {
+        const cap = toFinite(valueModel.combatPointCap);
+        if (cap == null || cap <= 0) {
+            return { ok: false, error: 'valueModel-combatPointCap-invalid' };
+        }
+    }
+
+    if (isPlainObject(valueModel.weights)) {
+        for (const [key, value] of Object.entries(valueModel.weights)) {
+            const num = toFinite(value);
+            if (num == null || num < 0) {
+                return { ok: false, error: `valueModel-weight-${key}-invalid` };
+            }
+        }
+    }
+
+    return { ok: true };
+}
+
+module.exports = {
+    isPlainObject,
+    cloneJson,
+    mergeObjects,
+    normalizePolicyPatch,
+    applyPolicyPatch,
+    validateRanks,
+    validatePolicy,
+};

--- a/apps/proxy-pool-service/src/policy.test.js
+++ b/apps/proxy-pool-service/src/policy.test.js
@@ -1,0 +1,158 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+    isPlainObject,
+    cloneJson,
+    mergeObjects,
+    normalizePolicyPatch,
+    applyPolicyPatch,
+    validateRanks,
+    validatePolicy,
+} = require('./policy');
+
+// 0229_basePolicy_基础策略逻辑
+function basePolicy() {
+    return {
+        serviceHourScale: 3,
+        promotionProtectHours: 6,
+        ranks: [
+            { rank: '新兵', minHours: 0, minPoints: 0, minSamples: 0 },
+            { rank: '列兵', minHours: 1, minPoints: 2, minSamples: 3 },
+        ],
+        scoring: {
+            success: 6,
+            successFastBonusLt1200: 2,
+            successFastBonusLt2500: 1,
+            blocked: -8,
+            timeout: -6,
+            networkError: -5,
+            invalidFeedback: -10,
+        },
+        demotion: {
+            regularWindowSize: 50,
+            regularBlockedRatio: 0.45,
+            regularMinSamples: 20,
+            severeWindowMinutes: 60,
+            severeMinSamples: 15,
+            severeBlockedRatio: 0.7,
+            healthThreshold: 45,
+            lowHealthRetireThreshold: 20,
+        },
+        retirement: {
+            disciplineThreshold: 40,
+            disciplineInvalidCount: 5,
+            technicalMinSamples: 60,
+            technicalSuccessRatio: 0.1,
+            battleDamageBlockedRatio: 0.6,
+            honorMinServiceHours: 720,
+            honorMinSuccess: 800,
+        },
+        honors: {
+            steelStreak: 30,
+            riskyWarrior: 20,
+            thousandService: 1000,
+        },
+        valueModel: {
+            combatPointCap: 1200,
+            weights: {
+                combat: 24,
+            },
+        },
+    };
+}
+
+test('policy helpers should cover object cloning and merging', () => {
+    assert.equal(isPlainObject({}), true);
+    assert.equal(isPlainObject([]), false);
+    assert.equal(isPlainObject(null), false);
+
+    const raw = { a: 1, b: { c: 2 }, d: [1, 2] };
+    const cloned = cloneJson(raw);
+    cloned.b.c = 9;
+    assert.equal(raw.b.c, 2);
+
+    const merged = mergeObjects(
+        { a: 1, b: { c: 2, d: 3 }, e: [1, 2] },
+        { b: { c: 9 }, e: [3], f: 7 },
+    );
+    assert.deepEqual(merged, { a: 1, b: { c: 9, d: 3 }, e: [3], f: 7 });
+    assert.deepEqual(mergeObjects(null, { x: 1 }), { x: 1 });
+});
+
+test('normalizePolicyPatch should validate patch shape and supported fields', () => {
+    assert.equal(normalizePolicyPatch(null).ok, false);
+    assert.equal(normalizePolicyPatch('x').error, 'invalid-policy-patch');
+    assert.equal(normalizePolicyPatch({ x: 1 }).error, 'unsupported-policy-field:x');
+    assert.deepEqual(
+        normalizePolicyPatch({ policy: { promotionProtectHours: 4 } }),
+        { ok: true, patch: { promotionProtectHours: 4 } },
+    );
+});
+
+test('applyPolicyPatch should merge nested objects', () => {
+    const next = applyPolicyPatch(basePolicy(), {
+        scoring: {
+            success: 8,
+        },
+        honors: {
+            steelStreak: 20,
+        },
+    });
+    assert.equal(next.scoring.success, 8);
+    assert.equal(next.honors.steelStreak, 20);
+    assert.equal(next.honors.riskyWarrior, 20);
+});
+
+test('validateRanks should validate ordering and shape', () => {
+    assert.equal(validateRanks([]), 'ranks-empty');
+    assert.equal(validateRanks([{ rank: '', minHours: 0, minPoints: 0, minSamples: 0 }]), 'rank-item-invalid');
+    assert.equal(validateRanks([{ rank: '新兵', minHours: 'x', minPoints: 0, minSamples: 0 }]), 'rank-threshold-invalid');
+    assert.equal(validateRanks([{ rank: '新兵', minHours: -1, minPoints: 0, minSamples: 0 }]), 'rank-threshold-negative');
+    assert.equal(validateRanks([
+        { rank: '新兵', minHours: 1, minPoints: 2, minSamples: 3 },
+        { rank: '列兵', minHours: 0, minPoints: 1, minSamples: 2 },
+    ]), 'rank-threshold-not-ascending');
+    assert.equal(validateRanks(basePolicy().ranks), null);
+});
+
+test('validatePolicy should cover invalid branches and success', () => {
+    assert.equal(validatePolicy(null).error, 'policy-invalid');
+
+    const p1 = basePolicy();
+    p1.serviceHourScale = 0;
+    assert.equal(validatePolicy(p1).error, 'serviceHourScale-invalid');
+
+    const p2 = basePolicy();
+    p2.promotionProtectHours = -1;
+    assert.equal(validatePolicy(p2).error, 'promotionProtectHours-invalid');
+
+    const p3 = basePolicy();
+    p3.ranks = [];
+    assert.equal(validatePolicy(p3).error, 'ranks-empty');
+
+    const p4 = basePolicy();
+    p4.demotion.regularBlockedRatio = 1.5;
+    assert.equal(validatePolicy(p4).error, 'ratio-invalid');
+
+    const p5 = basePolicy();
+    p5.honors.steelStreak = 0;
+    assert.equal(validatePolicy(p5).error, 'honors-steelStreak-invalid');
+
+    const p6 = basePolicy();
+    p6.valueModel.combatPointCap = 0;
+    assert.equal(validatePolicy(p6).error, 'valueModel-combatPointCap-invalid');
+
+    const p7 = basePolicy();
+    p7.valueModel.weights.combat = -1;
+    assert.equal(validatePolicy(p7).error, 'valueModel-weight-combat-invalid');
+
+    const p8 = basePolicy();
+    delete p8.honors;
+    assert.equal(validatePolicy(p8).error, 'honors-steelStreak-invalid');
+
+    const p9 = basePolicy();
+    delete p9.valueModel;
+    assert.equal(validatePolicy(p9).ok, true);
+
+    assert.equal(validatePolicy(basePolicy()).ok, true);
+});

--- a/apps/proxy-pool-service/src/rank.js
+++ b/apps/proxy-pool-service/src/rank.js
@@ -1,4 +1,5 @@
-﻿const { RANKS, RETIREMENT_TYPES, HONOR_TYPES } = require('./constants');
+const { RANKS, RETIREMENT_TYPES, HONOR_TYPES } = require('./constants');
+const { computeProxyValue } = require('./value-model');
 
 // 0081_clamp_限制逻辑
 function clamp(value, min, max) {
@@ -51,6 +52,13 @@ function scoreDelta(outcome, latencyMs, scoring) {
     let delta = 0;
     if (outcome === 'success') {
         delta += scoring.success;
+        if (Number.isFinite(latencyMs) && latencyMs > 0) {
+            if (latencyMs < 1200) {
+                delta += scoring.successFastBonusLt1200 || 0;
+            } else if (latencyMs < 2500) {
+                delta += scoring.successFastBonusLt2500 || 0;
+            }
+        }
     } else if (outcome === 'blocked') {
         delta += scoring.blocked;
     } else if (outcome === 'timeout') {
@@ -289,6 +297,9 @@ function evaluateCombat({ proxy, outcome, latencyMs, nowIso, config }) {
     updates.recent_window_json = JSON.stringify(trimmedWindow);
     updates.honor_history_json = JSON.stringify(honorHistory);
     updates.honor_active_json = JSON.stringify(activeHonors);
+    const valuation = computeProxyValue({ ...proxy, ...updates }, policy);
+    updates.ip_value_score = valuation.score;
+    updates.ip_value_breakdown_json = JSON.stringify(valuation.breakdown);
     updates.is_applied = 1;
 
     return {
@@ -327,10 +338,21 @@ function evaluateStateTransition({ proxy, nowIso, config }) {
         }
     }
 
+    const valuation = computeProxyValue(
+        {
+            ...proxy,
+            lifecycle,
+            retired_type: retiredType,
+        },
+        config.policy,
+    );
+
     return {
         updates: {
             lifecycle,
             retired_type: retiredType,
+            ip_value_score: valuation.score,
+            ip_value_breakdown_json: JSON.stringify(valuation.breakdown),
             updated_at: nowIso,
         },
         change,

--- a/apps/proxy-pool-service/src/rank.test.js
+++ b/apps/proxy-pool-service/src/rank.test.js
@@ -107,6 +107,38 @@ test('success should use fixed score mapping', () => {
     assert.equal(result.updates.combat_points, 6);
 });
 
+test('success should apply latency bonus branches', () => {
+    const cfg = baseConfig();
+    cfg.policy.scoring.successFastBonusLt1200 = 2;
+    cfg.policy.scoring.successFastBonusLt2500 = 1;
+
+    const fast = evaluateCombat({
+        proxy: baseProxy(),
+        outcome: 'success',
+        latencyMs: 900,
+        nowIso: new Date().toISOString(),
+        config: cfg,
+    });
+    const medium = evaluateCombat({
+        proxy: baseProxy(),
+        outcome: 'success',
+        latencyMs: 1800,
+        nowIso: new Date().toISOString(),
+        config: cfg,
+    });
+    const slow = evaluateCombat({
+        proxy: baseProxy(),
+        outcome: 'success',
+        latencyMs: 3000,
+        nowIso: new Date().toISOString(),
+        config: cfg,
+    });
+
+    assert.equal(fast.updates.combat_points, 8);
+    assert.equal(medium.updates.combat_points, 7);
+    assert.equal(slow.updates.combat_points, 6);
+});
+
 test('should promote when hours, points and samples all pass thresholds', () => {
     const cfg = baseConfig();
     const proxy = {
@@ -472,6 +504,8 @@ test('evaluateCombat should handle unknown rank/lifecycle and null scores', () =
     assert.equal(result.updates.rank, '未知军衔');
     assert.equal(result.updates.lifecycle, 'candidate');
     assert.equal(result.updates.discipline_score <= 100, true);
+    assert.equal(typeof result.updates.ip_value_score, 'number');
+    assert.equal(typeof result.updates.ip_value_breakdown_json, 'string');
 });
 
 test('safeParseJson should return parsed object when fallback is object', () => {
@@ -497,4 +531,24 @@ test('evaluateCombat should fallback rank when proxy rank is missing', () => {
     });
 
     assert.equal(result.updates.rank === '新兵' || result.updates.rank === '列兵', true);
+});
+
+test('state transition updates should include value score fields', () => {
+    const cfg = baseConfig();
+    const proxy = {
+        ...baseProxy(),
+        lifecycle: 'reserve',
+        health_score: 70,
+        recent_window_json: JSON.stringify([
+            { t: new Date().toISOString(), o: 'success' },
+            { t: new Date().toISOString(), o: 'success' },
+        ]),
+    };
+    const result = evaluateStateTransition({
+        proxy,
+        nowIso: new Date().toISOString(),
+        config: cfg,
+    });
+    assert.equal(typeof result.updates.ip_value_score, 'number');
+    assert.equal(typeof result.updates.ip_value_breakdown_json, 'string');
 });

--- a/apps/proxy-pool-service/src/server.js
+++ b/apps/proxy-pool-service/src/server.js
@@ -7,6 +7,7 @@ const { WorkerPool } = require('./worker-pool');
 const { ProxyHubEngine } = require('./engine');
 const { renderProxyAdminPage } = require('./views/proxy-admin');
 const { renderRuntimeLogsPage } = require('./views/runtime-logs');
+const { normalizePolicyPatch, applyPolicyPatch, validatePolicy } = require('./policy');
 
 // 0091_sendSse_发送SSE逻辑
 function sendSse(res, payload) {
@@ -119,6 +120,55 @@ function createRuntime(options = {}) {
         const limit = normalizeLimit(req.query.limit, 200, 1, 500);
         res.json({
             items: db.getBattleTestRuns(limit),
+        });
+    });
+
+    app.get('/v1/proxies/value-board', (req, res) => {
+        const limit = normalizeLimit(req.query.limit, 100, 1, 500);
+        const lifecycle = req.query.lifecycle ? String(req.query.lifecycle) : undefined;
+        res.json({
+            items: db.getValueBoard(limit, lifecycle),
+        });
+    });
+
+    app.get('/v1/proxies/policy', (_req, res) => {
+        res.json({
+            policy: config.policy,
+        });
+    });
+
+    app.post('/v1/proxies/policy', (req, res) => {
+        const normalized = normalizePolicyPatch(req.body);
+        if (!normalized.ok) {
+            res.status(400).json({
+                ok: false,
+                error: normalized.error,
+            });
+            return;
+        }
+
+        const nextPolicy = applyPolicyPatch(config.policy, normalized.patch);
+        const validation = validatePolicy(nextPolicy);
+        if (!validation.ok) {
+            res.status(400).json({
+                ok: false,
+                error: validation.error,
+            });
+            return;
+        }
+
+        config.policy = nextPolicy;
+        logger.write({
+            event: '策略调整',
+            stage: '策略',
+            result: '策略已更新',
+            action: '即时生效',
+            details: normalized.patch,
+        });
+
+        res.json({
+            ok: true,
+            policy: config.policy,
         });
     });
 

--- a/apps/proxy-pool-service/src/server.test.js
+++ b/apps/proxy-pool-service/src/server.test.js
@@ -39,10 +39,17 @@ function createConfig(port = 0) {
             demotion: { regularWindowSize: 50, regularBlockedRatio: 0.45, regularMinSamples: 3, severeWindowMinutes: 60, severeMinSamples: 3, severeBlockedRatio: 0.7, healthThreshold: 45, lowHealthRetireThreshold: 20 },
             retirement: { disciplineThreshold: 40, disciplineInvalidCount: 2, technicalMinSamples: 6, technicalSuccessRatio: 0.1, battleDamageBlockedRatio: 0.6, honorMinServiceHours: 500, honorMinSuccess: 800 },
             honors: { steelStreak: 3, riskyWarrior: 3, thousandService: 10 },
+            valueModel: {
+                combatPointCap: 1200,
+                honorActiveWeight: 30,
+                honorHistoryWeight: 10,
+                weights: { rank: 16, combat: 24, health: 16, discipline: 14, successRatio: 12, battleRatio: 10, honor: 8 },
+                lifecycleScoreMap: { active: 100, reserve: 72, candidate: 58, retired: 8 },
+            },
         },
         storage: { dbPath: 'unused.db', snapshotRetentionDays: 7 },
         ui: { refreshMs: 5000 },
-        soak: { durationHours: 24, summaryIntervalMs: 3600000 },
+        soak: { durationHours: 10, summaryIntervalMs: 3600000 },
     };
 }
 
@@ -59,6 +66,7 @@ function createStubs() {
         getProxyList: () => [{ id: 1 }],
         getEvents: () => [{ id: 2 }],
         getBattleTestRuns: () => [{ id: 6, stage: 'l1' }],
+        getValueBoard: () => [{ id: 7, ip_value_score: 88.8 }],
         getRankBoard: () => [{ rank: '新兵', count: 1 }],
         getHonors: () => [{ id: 3 }],
         getRetirements: () => [{ id: 4 }],
@@ -140,6 +148,9 @@ test('server runtime should expose all REST endpoints and shutdown cleanly', asy
         '/v1/proxies/list?limit=10&rank=%E5%88%97%E5%85%B5&lifecycle=active',
         '/v1/proxies/events?limit=0',
         '/v1/proxies/battle-tests?limit=1000',
+        '/v1/proxies/value-board?limit=20',
+        '/v1/proxies/value-board?limit=20&lifecycle=active',
+        '/v1/proxies/policy',
         '/v1/proxies/ranks/board',
         '/v1/proxies/honors?limit=1000',
         '/v1/proxies/retirements?limit=-1',
@@ -150,6 +161,32 @@ test('server runtime should expose all REST endpoints and shutdown cleanly', asy
         const res = await fetch(baseUrl + p, { signal: AbortSignal.timeout(10000) });
         assert.equal(res.status, 200);
     }
+
+    const patchOk = await fetch(baseUrl + '/v1/proxies/policy', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+            promotionProtectHours: 4,
+            honors: { steelStreak: 2, riskyWarrior: 2, thousandService: 8 },
+        }),
+    });
+    assert.equal(patchOk.status, 200);
+
+    const patchInvalidBody = await fetch(baseUrl + '/v1/proxies/policy', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify([]),
+    });
+    assert.equal(patchInvalidBody.status, 400);
+
+    const patchInvalidValue = await fetch(baseUrl + '/v1/proxies/policy', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+            retirement: { technicalSuccessRatio: 2 },
+        }),
+    });
+    assert.equal(patchInvalidValue.status, 400);
 
     const sseLogs = await fetch(baseUrl + '/api/runtime/logs/stream', {
         headers: { Accept: 'text/event-stream' },
@@ -175,6 +212,7 @@ test('server start should reject when listen emits error', async () => {
     const fakeApp = new EventEmitter();
     fakeApp.use = () => {};
     fakeApp.get = () => {};
+    fakeApp.post = () => {};
     fakeApp.listen = () => {
         const server = new EventEmitter();
         server.close = (cb) => cb();
@@ -191,6 +229,7 @@ test('server start should handle sync listen throw and engine async start failur
     const fakeAppThrow = new EventEmitter();
     fakeAppThrow.use = () => {};
     fakeAppThrow.get = () => {};
+    fakeAppThrow.post = () => {};
     fakeAppThrow.listen = () => {
         throw new Error('listen-throw');
     };

--- a/apps/proxy-pool-service/src/soak.js
+++ b/apps/proxy-pool-service/src/soak.js
@@ -24,6 +24,7 @@ function createSoakRuntime(options = {}) {
     const durationHours = Number(process.env.SOAK_HOURS || config.soak.durationHours);
     const pollMs = Number(process.env.SOAK_POLL_MS || 30_000);
     const summaryMs = Number(process.env.SOAK_SUMMARY_MS || config.soak.summaryIntervalMs);
+    const policyActionsFile = String(process.env.SOAK_POLICY_ACTIONS_FILE || '').trim();
 
     const state = {
         child: null,
@@ -37,6 +38,12 @@ function createSoakRuntime(options = {}) {
         healthOkSamples: 0,
         startedBySoak: false,
         lastPool: null,
+        lastValueBoard: [],
+        policyActions: [],
+        policyActionsPlanned: 0,
+        policyActionsApplied: 0,
+        policyActionFailures: 0,
+        nextPolicyActionIndex: 0,
     };
 
     // 0118_appendTimeline_执行appendTimeline相关逻辑
@@ -54,6 +61,159 @@ function createSoakRuntime(options = {}) {
             throw new Error(`http-${res.status}`);
         }
         return res.json();
+    }
+
+    // 0131_httpPostJson_提交JSON逻辑
+    async function httpPostJson(url, payload) {
+        const res = await fetchImpl(url, {
+            method: 'POST',
+            headers: {
+                'content-type': 'application/json',
+            },
+            body: JSON.stringify(payload),
+            signal: AbortSignal.timeout(10_000),
+        });
+        if (!res.ok) {
+            throw new Error(`http-${res.status}`);
+        }
+        return res.json();
+    }
+
+    // 0132_defaultPolicyActions_默认策略动作逻辑
+    function defaultPolicyActions() {
+        if (durationHours < 10) {
+            return [];
+        }
+
+        const policy = config.policy || {};
+        return [
+            {
+                atMinute: 60,
+                note: '调整晋升保护窗口',
+                patch: {
+                    promotionProtectHours: Math.max(1, Number(policy.promotionProtectHours || 6) - 2),
+                },
+            },
+            {
+                atMinute: 180,
+                note: '提高技术退伍门槛',
+                patch: {
+                    retirement: {
+                        technicalSuccessRatio: Number((Number(policy.retirement?.technicalSuccessRatio || 0.1) + 0.02).toFixed(2)),
+                    },
+                },
+            },
+            {
+                atMinute: 300,
+                note: '提高纪律退伍阈值',
+                patch: {
+                    retirement: {
+                        disciplineThreshold: Math.min(90, Number(policy.retirement?.disciplineThreshold || 40) + 3),
+                    },
+                },
+            },
+            {
+                atMinute: 420,
+                note: '下调荣誉触发阈值',
+                patch: {
+                    honors: {
+                        steelStreak: Math.max(5, Number(policy.honors?.steelStreak || 30) - 5),
+                        riskyWarrior: Math.max(3, Number(policy.honors?.riskyWarrior || 20) - 3),
+                        thousandService: Math.max(100, Number(policy.honors?.thousandService || 1000) - 100),
+                    },
+                },
+            },
+            {
+                atMinute: 540,
+                note: '加强价值评分中的实战权重',
+                patch: {
+                    valueModel: {
+                        weights: {
+                            combat: 26,
+                            successRatio: 14,
+                            battleRatio: 12,
+                            honor: 9,
+                        },
+                    },
+                },
+            },
+        ];
+    }
+
+    // 0133_normalizePolicyActions_规范化策略动作逻辑
+    function normalizePolicyActions(rawActions) {
+        if (!Array.isArray(rawActions)) return [];
+        return rawActions
+            .map((item) => {
+                const atMinute = Number(item?.atMinute);
+                if (!Number.isFinite(atMinute) || atMinute < 0 || typeof item?.patch !== 'object' || Array.isArray(item.patch) || !item.patch) {
+                    return null;
+                }
+                return {
+                    atMinute,
+                    note: String(item.note || '策略调整'),
+                    patch: item.patch,
+                };
+            })
+            .filter(Boolean)
+            .sort((a, b) => a.atMinute - b.atMinute);
+    }
+
+    // 0134_loadPolicyActions_加载策略动作逻辑
+    function loadPolicyActions() {
+        let actions = [];
+
+        if (policyActionsFile) {
+            try {
+                const raw = fsImpl.readFileSync(policyActionsFile, 'utf8');
+                actions = normalizePolicyActions(JSON.parse(raw));
+                appendTimeline('policy_actions_loaded', {
+                    source: policyActionsFile,
+                    count: actions.length,
+                });
+            } catch (error) {
+                appendTimeline('policy_actions_load_failed', {
+                    source: policyActionsFile,
+                    reason: error?.message || 'load-policy-actions-failed',
+                });
+            }
+        } else {
+            actions = normalizePolicyActions(defaultPolicyActions());
+        }
+
+        state.policyActions = actions;
+        state.policyActionsPlanned = actions.length;
+        state.nextPolicyActionIndex = 0;
+        return actions;
+    }
+
+    // 0135_applyPendingPolicyActions_应用待执行策略动作逻辑
+    async function applyPendingPolicyActions(elapsedMs) {
+        const elapsedMinutes = elapsedMs / 60_000;
+        while (state.nextPolicyActionIndex < state.policyActions.length) {
+            const action = state.policyActions[state.nextPolicyActionIndex];
+            if (elapsedMinutes < action.atMinute) {
+                break;
+            }
+
+            try {
+                await httpPostJson(`${baseUrl}/v1/proxies/policy`, action.patch);
+                state.policyActionsApplied += 1;
+                appendTimeline('policy_action_applied', {
+                    atMinute: action.atMinute,
+                    note: action.note,
+                });
+            } catch (error) {
+                state.policyActionFailures += 1;
+                appendTimeline('policy_action_failed', {
+                    atMinute: action.atMinute,
+                    note: action.note,
+                    reason: error?.message || 'policy-action-failed',
+                });
+            }
+
+            state.nextPolicyActionIndex += 1;
+        }
     }
 
     // 0120_ensureService_确保逻辑
@@ -135,10 +295,10 @@ function createSoakRuntime(options = {}) {
     }
 
     // 0122_writeFinalReport_写入逻辑
-    function writeFinalReport(endAt) {
+    function writeFinalReport(endAt, valueBoard = []) {
         const uptimeRatio = state.samples > 0 ? (state.healthOkSamples / state.samples) * 100 : 0;
         const lines = [
-            '# ProxyHub V1 24h Soak 报告',
+            `# ProxyHub V1 ${durationHours}h Soak 报告`,
             '',
             `- 启动时间: ${startedAt.toISOString()}`,
             `- 结束时间: ${endAt.toISOString()}`,
@@ -153,6 +313,14 @@ function createSoakRuntime(options = {}) {
             `- 最大忙碌线程: ${state.maxBusy}`,
             `- 最大失败任务计数: ${state.maxFailedTasks}`,
             `- 最后线程池状态: ${state.lastPool ? JSON.stringify(state.lastPool) : 'N/A'}`,
+            `- 策略动作计划数: ${state.policyActionsPlanned}`,
+            `- 策略动作成功: ${state.policyActionsApplied}`,
+            `- 策略动作失败: ${state.policyActionFailures}`,
+            '',
+            '## IP价值榜 Top 10',
+            ...(Array.isArray(valueBoard) && valueBoard.length > 0
+                ? valueBoard.map((item, index) => `- ${index + 1}. ${item.display_name} | 价值分 ${Number(item.ip_value_score || 0).toFixed(2)} | 军衔 ${item.rank || '-'} | 生命周期 ${item.lifecycle || '-'}`)
+                : ['- 无可用样本']),
             '',
             '## 异常修复时间线',
             `- 详见 ${timelineFile}`,
@@ -168,19 +336,23 @@ function createSoakRuntime(options = {}) {
 
     // 0123_runSoak_执行逻辑
     async function runSoak() {
+        loadPolicyActions();
         appendTimeline('soak_start', {
             durationHours,
             pollMs,
             summaryMs,
             baseUrl,
+            policyActionsPlanned: state.policyActionsPlanned,
         });
 
         await ensureService();
 
+        const loopStartedMs = Date.now();
         const endTime = Date.now() + durationHours * 3_600_000;
         let nextSummary = Date.now() + summaryMs;
 
         while (Date.now() < endTime) {
+            await applyPendingPolicyActions(Date.now() - loopStartedMs);
             await pollOnce();
 
             if (Date.now() >= nextSummary) {
@@ -199,8 +371,20 @@ function createSoakRuntime(options = {}) {
             await new Promise((r) => setTimeout(r, pollMs));
         }
 
+        await applyPendingPolicyActions(Date.now() - loopStartedMs + 60_000);
+        let valueBoard = [];
+        try {
+            const valuePayload = await httpGetJson(`${baseUrl}/v1/proxies/value-board?limit=10`);
+            valueBoard = Array.isArray(valuePayload?.items) ? valuePayload.items : [];
+        } catch (error) {
+            appendTimeline('value_board_fetch_failed', {
+                reason: error?.message || 'value-board-fetch-failed',
+            });
+        }
+        state.lastValueBoard = valueBoard;
+
         const endAt = now();
-        writeFinalReport(endAt);
+        writeFinalReport(endAt, valueBoard);
         appendTimeline('soak_end', {
             reportFile,
             timelineFile,
@@ -246,6 +430,10 @@ function createSoakRuntime(options = {}) {
         summaryMs,
         appendTimeline,
         httpGetJson,
+        httpPostJson,
+        normalizePolicyActions,
+        loadPolicyActions,
+        applyPendingPolicyActions,
         ensureService,
         pollOnce,
         writeFinalReport,

--- a/apps/proxy-pool-service/src/soak.test.js
+++ b/apps/proxy-pool-service/src/soak.test.js
@@ -23,7 +23,19 @@ async function withTempCwd(fn) {
 function makeConfig() {
     return {
         service: { port: 5070 },
-        soak: { durationHours: 24, summaryIntervalMs: 3600000 },
+        soak: { durationHours: 10, summaryIntervalMs: 3600000 },
+        policy: {
+            promotionProtectHours: 6,
+            retirement: {
+                technicalSuccessRatio: 0.1,
+                disciplineThreshold: 40,
+            },
+            honors: {
+                steelStreak: 30,
+                riskyWarrior: 20,
+                thousandService: 1000,
+            },
+        },
     };
 }
 
@@ -175,9 +187,14 @@ test('writeFinalReport should produce markdown file', async () => {
         runtime.state.maxBusy = 1;
         runtime.state.maxFailedTasks = 0;
 
-        runtime.writeFinalReport(new Date('2026-03-14T00:00:00.000Z'));
+        runtime.writeFinalReport(new Date('2026-03-14T00:00:00.000Z'), [
+            { display_name: '价值-1', ip_value_score: 77.3, rank: '士官', lifecycle: 'active' },
+            { display_name: '价值-2' },
+        ]);
         const content = fs.readFileSync(runtime.reportFile, 'utf8');
-        assert.equal(content.includes('ProxyHub V1 24h Soak 报告'), true);
+        assert.equal(content.includes('ProxyHub V1 10h Soak 报告'), true);
+        assert.equal(content.includes('IP价值榜 Top 10'), true);
+        assert.equal(content.includes('价值分 0.00'), true);
     });
 });
 
@@ -190,6 +207,93 @@ test('writeFinalReport should handle zero samples uptime branch', async () => {
         runtime.writeFinalReport(new Date('2026-03-14T00:00:00.000Z'));
         const content = fs.readFileSync(runtime.reportFile, 'utf8');
         assert.equal(content.includes('可用率: 0.00%'), true);
+        assert.equal(content.includes('无可用样本'), true);
+    });
+});
+
+test('normalize/load policy actions should cover file and invalid branches', async () => {
+    await withTempCwd(async (cwd) => {
+        const actionsFile = path.join(cwd, 'actions.json');
+        fs.writeFileSync(actionsFile, JSON.stringify([
+            { atMinute: 0, note: 'ok', patch: { promotionProtectHours: 4 } },
+            { atMinute: -1, note: 'bad', patch: { promotionProtectHours: 3 } },
+            { atMinute: 10, note: 'bad2', patch: [] },
+        ]), 'utf8');
+
+        const oldPath = process.env.SOAK_POLICY_ACTIONS_FILE;
+        process.env.SOAK_POLICY_ACTIONS_FILE = actionsFile;
+        const runtime = createSoakRuntime({
+            config: makeConfig(),
+            fetchImpl: async () => ({ ok: true, status: 200, async json() { return {}; } }),
+        });
+
+        const normalized = runtime.normalizePolicyActions([{ atMinute: 2, patch: { a: 1 } }, { atMinute: -1, patch: { b: 2 } }]);
+        assert.equal(normalized.length, 1);
+        assert.deepEqual(runtime.normalizePolicyActions(null), []);
+
+        const loaded = runtime.loadPolicyActions();
+        assert.equal(loaded.length, 1);
+        assert.equal(runtime.state.policyActionsPlanned, 1);
+
+        process.env.SOAK_POLICY_ACTIONS_FILE = path.join(cwd, 'missing.json');
+        const runtime2 = createSoakRuntime({
+            config: makeConfig(),
+            fetchImpl: async () => ({ ok: true, status: 200, async json() { return {}; } }),
+        });
+        const loaded2 = runtime2.loadPolicyActions();
+        assert.equal(Array.isArray(loaded2), true);
+
+        process.env.SOAK_POLICY_ACTIONS_FILE = oldPath;
+    });
+});
+
+test('loadPolicyActions should return default 10h action plan without env file', async () => {
+    await withTempCwd(async () => {
+        const oldPath = process.env.SOAK_POLICY_ACTIONS_FILE;
+        process.env.SOAK_POLICY_ACTIONS_FILE = '';
+        const runtime = createSoakRuntime({
+            config: makeConfig(),
+            fetchImpl: async () => ({ ok: true, status: 200, async json() { return {}; } }),
+        });
+        const loaded = runtime.loadPolicyActions();
+        assert.equal(loaded.length > 0, true);
+        assert.equal(runtime.state.policyActionsPlanned, loaded.length);
+        process.env.SOAK_POLICY_ACTIONS_FILE = oldPath;
+    });
+});
+
+test('loadPolicyActions should fallback when policy fields are missing', async () => {
+    await withTempCwd(async () => {
+        const oldPath = process.env.SOAK_POLICY_ACTIONS_FILE;
+        process.env.SOAK_POLICY_ACTIONS_FILE = '';
+        const runtime = createSoakRuntime({
+            config: {
+                service: { port: 5070 },
+                soak: { durationHours: 10, summaryIntervalMs: 3600000 },
+                policy: {},
+            },
+            fetchImpl: async () => ({ ok: true, status: 200, async json() { return {}; } }),
+        });
+        const loaded = runtime.loadPolicyActions();
+        assert.equal(loaded.length, 5);
+        assert.equal(loaded[0].patch.promotionProtectHours >= 1, true);
+        process.env.SOAK_POLICY_ACTIONS_FILE = oldPath;
+    });
+});
+
+test('loadPolicyActions should write fallback reason when read throws null', async () => {
+    await withTempCwd(async () => {
+        const oldPath = process.env.SOAK_POLICY_ACTIONS_FILE;
+        process.env.SOAK_POLICY_ACTIONS_FILE = 'x.json';
+        const runtime = createSoakRuntime({
+            config: makeConfig(),
+            fsImpl: { ...fs, readFileSync: () => { throw null; } },
+            fetchImpl: async () => ({ ok: true, status: 200, async json() { return {}; } }),
+        });
+        runtime.loadPolicyActions();
+        const content = fs.readFileSync(runtime.timelineFile, 'utf8');
+        assert.equal(content.includes('load-policy-actions-failed'), true);
+        process.env.SOAK_POLICY_ACTIONS_FILE = oldPath;
     });
 });
 
@@ -201,6 +305,7 @@ test('runSoak should complete loop, write report, and kill child when managed', 
             SOAK_HOURS: process.env.SOAK_HOURS,
             SOAK_POLL_MS: process.env.SOAK_POLL_MS,
             SOAK_SUMMARY_MS: process.env.SOAK_SUMMARY_MS,
+            SOAK_POLICY_ACTIONS_FILE: process.env.SOAK_POLICY_ACTIONS_FILE,
         };
         const oldNow = Date.now;
         let nowMs = 1700000000000;
@@ -214,6 +319,13 @@ test('runSoak should complete loop, write report, and kill child when managed', 
             return nowMs;
         };
 
+        const actionsFile = path.join(process.cwd(), 'actions.json');
+        fs.writeFileSync(actionsFile, JSON.stringify([
+            { atMinute: 0, note: '调参', patch: { promotionProtectHours: 3 } },
+        ]), 'utf8');
+
+        process.env.SOAK_POLICY_ACTIONS_FILE = actionsFile;
+
         const runtime = createSoakRuntime({
             config: makeConfig(),
             fetchImpl: async (url) => {
@@ -224,6 +336,12 @@ test('runSoak should complete loop, write report, and kill child when managed', 
                     }
                     return { ok: true, status: 200, async json() { return { ok: true }; } };
                 }
+                if (url.endsWith('/v1/proxies/policy')) {
+                    return { ok: true, status: 200, async json() { return { ok: true }; } };
+                }
+                if (url.includes('/v1/proxies/value-board')) {
+                    return { ok: true, status: 200, async json() { return { items: [{ display_name: 'V1', ip_value_score: 90, rank: '尉官', lifecycle: 'active' }] }; } };
+                }
                 return { ok: true, status: 200, async json() { return { poolStatus: { queueSize: 0, workersBusy: 0, workersTotal: 1, failedTasks: 0, restartedWorkers: 0, completedTasks: 0 } }; } };
             },
             spawnImpl: () => child,
@@ -233,11 +351,155 @@ test('runSoak should complete loop, write report, and kill child when managed', 
         assert.equal(fs.existsSync(result.reportFile), true);
         assert.equal(fs.existsSync(result.timelineFile), true);
         assert.equal(child.killSignal, 'SIGTERM');
+        assert.equal(runtime.state.policyActionsApplied, 1);
+        assert.equal(runtime.state.lastValueBoard.length, 1);
 
         Date.now = oldNow;
         process.env.SOAK_HOURS = oldEnv.SOAK_HOURS;
         process.env.SOAK_POLL_MS = oldEnv.SOAK_POLL_MS;
         process.env.SOAK_SUMMARY_MS = oldEnv.SOAK_SUMMARY_MS;
+        process.env.SOAK_POLICY_ACTIONS_FILE = oldEnv.SOAK_POLICY_ACTIONS_FILE;
+    });
+});
+
+test('applyPendingPolicyActions should record failure and continue', async () => {
+    await withTempCwd(async () => {
+        const runtime = createSoakRuntime({
+            config: makeConfig(),
+            fetchImpl: async (url) => {
+                if (url.endsWith('/v1/proxies/policy')) {
+                    return { ok: false, status: 500, async json() { return {}; } };
+                }
+                return { ok: true, status: 200, async json() { return {}; } };
+            },
+        });
+        runtime.state.policyActions = [{ atMinute: 0, note: 'bad', patch: { promotionProtectHours: 2 } }];
+        runtime.state.policyActionsPlanned = 1;
+        await runtime.applyPendingPolicyActions(0);
+        assert.equal(runtime.state.policyActionFailures, 1);
+        assert.equal(runtime.state.nextPolicyActionIndex, 1);
+
+        const runtime2 = createSoakRuntime({
+            config: makeConfig(),
+            fetchImpl: async () => ({ ok: true, status: 200, async json() { return {}; } }),
+        });
+        runtime2.state.policyActions = [{ atMinute: 5, note: 'wait', patch: { promotionProtectHours: 2 } }];
+        await runtime2.applyPendingPolicyActions(0);
+        assert.equal(runtime2.state.nextPolicyActionIndex, 0);
+
+        const runtime3 = createSoakRuntime({
+            config: makeConfig(),
+            fetchImpl: async (url) => {
+                if (url.endsWith('/v1/proxies/policy')) {
+                    throw null;
+                }
+                return { ok: true, status: 200, async json() { return {}; } };
+            },
+        });
+        runtime3.state.policyActions = [{ atMinute: 0, note: 'nullerr', patch: { promotionProtectHours: 2 } }];
+        await runtime3.applyPendingPolicyActions(0);
+        const content = fs.readFileSync(runtime3.timelineFile, 'utf8');
+        assert.equal(content.includes('policy-action-failed'), true);
+    });
+});
+
+test('runSoak should record value-board fetch failure branch', async () => {
+    await withTempCwd(async () => {
+        const child = makeChild();
+        const oldEnv = {
+            SOAK_HOURS: process.env.SOAK_HOURS,
+            SOAK_POLL_MS: process.env.SOAK_POLL_MS,
+            SOAK_SUMMARY_MS: process.env.SOAK_SUMMARY_MS,
+            SOAK_POLICY_ACTIONS_FILE: process.env.SOAK_POLICY_ACTIONS_FILE,
+        };
+        const oldNow = Date.now;
+        let nowMs = 1700000000000;
+        process.env.SOAK_HOURS = '0.0002';
+        process.env.SOAK_POLL_MS = '1';
+        process.env.SOAK_SUMMARY_MS = '1';
+        process.env.SOAK_POLICY_ACTIONS_FILE = '';
+        Date.now = () => {
+            nowMs += 100;
+            return nowMs;
+        };
+
+        let healthChecks = 0;
+        const runtime = createSoakRuntime({
+            config: makeConfig(),
+            fetchImpl: async (url) => {
+                if (url.endsWith('/health')) {
+                    healthChecks += 1;
+                    if (healthChecks === 1) {
+                        throw new Error('down');
+                    }
+                    return { ok: true, status: 200, async json() { return { ok: true }; } };
+                }
+                if (url.includes('/v1/proxies/value-board')) {
+                    throw null;
+                }
+                return { ok: true, status: 200, async json() { return { poolStatus: { queueSize: 0, workersBusy: 0, workersTotal: 1, failedTasks: 0, restartedWorkers: 0, completedTasks: 0 } }; } };
+            },
+            spawnImpl: () => child,
+        });
+
+        await runtime.runSoak();
+        const timeline = fs.readFileSync(runtime.timelineFile, 'utf8');
+        assert.equal(timeline.includes('value_board_fetch_failed'), true);
+
+        Date.now = oldNow;
+        process.env.SOAK_HOURS = oldEnv.SOAK_HOURS;
+        process.env.SOAK_POLL_MS = oldEnv.SOAK_POLL_MS;
+        process.env.SOAK_SUMMARY_MS = oldEnv.SOAK_SUMMARY_MS;
+        process.env.SOAK_POLICY_ACTIONS_FILE = oldEnv.SOAK_POLICY_ACTIONS_FILE;
+    });
+});
+
+test('runSoak should handle non-array value-board payload branch', async () => {
+    await withTempCwd(async () => {
+        const child = makeChild();
+        const oldEnv = {
+            SOAK_HOURS: process.env.SOAK_HOURS,
+            SOAK_POLL_MS: process.env.SOAK_POLL_MS,
+            SOAK_SUMMARY_MS: process.env.SOAK_SUMMARY_MS,
+            SOAK_POLICY_ACTIONS_FILE: process.env.SOAK_POLICY_ACTIONS_FILE,
+        };
+        const oldNow = Date.now;
+        let nowMs = 1700000000000;
+        process.env.SOAK_HOURS = '0.0002';
+        process.env.SOAK_POLL_MS = '1';
+        process.env.SOAK_SUMMARY_MS = '1';
+        process.env.SOAK_POLICY_ACTIONS_FILE = '';
+        Date.now = () => {
+            nowMs += 100;
+            return nowMs;
+        };
+
+        let healthChecks = 0;
+        const runtime = createSoakRuntime({
+            config: makeConfig(),
+            fetchImpl: async (url) => {
+                if (url.endsWith('/health')) {
+                    healthChecks += 1;
+                    if (healthChecks === 1) throw new Error('down');
+                    return { ok: true, status: 200, async json() { return { ok: true }; } };
+                }
+                if (url.includes('/v1/proxies/value-board')) {
+                    return { ok: true, status: 200, async json() { return { items: {} }; } };
+                }
+                return { ok: true, status: 200, async json() { return { poolStatus: { queueSize: 0, workersBusy: 0, workersTotal: 1, failedTasks: 0, restartedWorkers: 0, completedTasks: 0 } }; } };
+            },
+            spawnImpl: () => child,
+        });
+
+        await runtime.runSoak();
+        assert.equal(Array.isArray(runtime.state.lastValueBoard), true);
+        assert.equal(runtime.state.lastValueBoard.length, 0);
+
+        Date.now = oldNow;
+        process.env.SOAK_HOURS = oldEnv.SOAK_HOURS;
+        process.env.SOAK_POLL_MS = oldEnv.SOAK_POLL_MS;
+        process.env.SOAK_SUMMARY_MS = oldEnv.SOAK_SUMMARY_MS;
+        process.env.SOAK_POLICY_ACTIONS_FILE = oldEnv.SOAK_POLICY_ACTIONS_FILE;
     });
 });
 

--- a/apps/proxy-pool-service/src/value-model.js
+++ b/apps/proxy-pool-service/src/value-model.js
@@ -1,0 +1,173 @@
+const { RANKS } = require('./constants');
+
+// 0214_toFiniteNumber_转换为有限数字逻辑
+function toFiniteNumber(value, fallback = 0) {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : fallback;
+}
+
+// 0215_clamp_限制逻辑
+function clamp(value, min, max) {
+    return Math.max(min, Math.min(max, value));
+}
+
+// 0216_parseJsonArray_解析JSON数组逻辑
+function parseJsonArray(value) {
+    try {
+        if (!value) return [];
+        if (Array.isArray(value)) return value;
+        const parsed = JSON.parse(value);
+        return Array.isArray(parsed) ? parsed : [];
+    } catch {
+        return [];
+    }
+}
+
+// 0217_safeRatio_安全比例逻辑
+function safeRatio(numerator, denominator, fallback = 0.5) {
+    const n = toFiniteNumber(numerator, 0);
+    const d = toFiniteNumber(denominator, 0);
+    if (d <= 0) return fallback;
+    return clamp(n / d, 0, 1);
+}
+
+const DEFAULT_MODEL = {
+    combatPointCap: 1200,
+    honorActiveWeight: 30,
+    honorHistoryWeight: 10,
+    weights: {
+        rank: 16,
+        combat: 24,
+        health: 16,
+        discipline: 14,
+        successRatio: 12,
+        battleRatio: 10,
+        honor: 8,
+    },
+    lifecycleScoreMap: {
+        active: 100,
+        reserve: 72,
+        candidate: 58,
+        retired: 8,
+    },
+};
+
+// 0218_resolveModel_解析模型配置逻辑
+function resolveModel(policy = {}) {
+    const custom = policy.valueModel || {};
+    return {
+        ...DEFAULT_MODEL,
+        ...custom,
+        weights: {
+            ...DEFAULT_MODEL.weights,
+            ...(custom.weights || {}),
+        },
+        lifecycleScoreMap: {
+            ...DEFAULT_MODEL.lifecycleScoreMap,
+            ...(custom.lifecycleScoreMap || {}),
+        },
+    };
+}
+
+// 0219_buildGrade_构建等级逻辑
+function buildGrade(score) {
+    if (score >= 85) return 'S';
+    if (score >= 70) return 'A';
+    if (score >= 55) return 'B';
+    if (score >= 40) return 'C';
+    return 'D';
+}
+
+// 0220_computeProxyValue_计算IP价值逻辑
+function computeProxyValue(proxy, policy = {}) {
+    const model = resolveModel(policy);
+
+    const rank = proxy.rank || RANKS[0];
+    const rankIdx = Math.max(0, RANKS.indexOf(rank));
+    const rankScore = RANKS.length > 1 ? (rankIdx / (RANKS.length - 1)) * 100 : 0;
+
+    const combatPointCap = Math.max(1, toFiniteNumber(model.combatPointCap, DEFAULT_MODEL.combatPointCap));
+    const combatScore = clamp((toFiniteNumber(proxy.combat_points, 0) / combatPointCap) * 100, 0, 100);
+    const healthScore = clamp(toFiniteNumber(proxy.health_score, 60), 0, 100);
+    const disciplineScore = clamp(toFiniteNumber(proxy.discipline_score, 100), 0, 100);
+    const successScore = safeRatio(proxy.success_count, proxy.total_samples, 0.5) * 100;
+    const battleScore = safeRatio(
+        proxy.battle_success_count,
+        toFiniteNumber(proxy.battle_success_count, 0) + toFiniteNumber(proxy.battle_fail_count, 0),
+        0.5,
+    ) * 100;
+
+    const honorActive = parseJsonArray(proxy.honor_active_json);
+    const honorHistory = parseJsonArray(proxy.honor_history_json);
+    const honorScore = clamp(
+        honorActive.length * Math.max(0, toFiniteNumber(model.honorActiveWeight, 30))
+            + honorHistory.length * Math.max(0, toFiniteNumber(model.honorHistoryWeight, 10)),
+        0,
+        100,
+    );
+
+    const lifecycle = String(proxy.lifecycle || 'candidate');
+    const lifecycleScore = clamp(
+        toFiniteNumber(model.lifecycleScoreMap[lifecycle], model.lifecycleScoreMap.candidate),
+        0,
+        100,
+    );
+
+    const components = {
+        rank: Number(rankScore.toFixed(2)),
+        combat: Number(combatScore.toFixed(2)),
+        health: Number(healthScore.toFixed(2)),
+        discipline: Number(disciplineScore.toFixed(2)),
+        successRatio: Number(successScore.toFixed(2)),
+        battleRatio: Number(battleScore.toFixed(2)),
+        honor: Number(honorScore.toFixed(2)),
+        lifecycle: Number(lifecycleScore.toFixed(2)),
+    };
+
+    const weights = {
+        rank: Math.max(0, toFiniteNumber(model.weights.rank, DEFAULT_MODEL.weights.rank)),
+        combat: Math.max(0, toFiniteNumber(model.weights.combat, DEFAULT_MODEL.weights.combat)),
+        health: Math.max(0, toFiniteNumber(model.weights.health, DEFAULT_MODEL.weights.health)),
+        discipline: Math.max(0, toFiniteNumber(model.weights.discipline, DEFAULT_MODEL.weights.discipline)),
+        successRatio: Math.max(0, toFiniteNumber(model.weights.successRatio, DEFAULT_MODEL.weights.successRatio)),
+        battleRatio: Math.max(0, toFiniteNumber(model.weights.battleRatio, DEFAULT_MODEL.weights.battleRatio)),
+        honor: Math.max(0, toFiniteNumber(model.weights.honor, DEFAULT_MODEL.weights.honor)),
+    };
+
+    const weightSum = Object.values(weights).reduce((acc, item) => acc + item, 0);
+    const weightedCore = weightSum > 0
+        ? (
+            components.rank * weights.rank
+            + components.combat * weights.combat
+            + components.health * weights.health
+            + components.discipline * weights.discipline
+            + components.successRatio * weights.successRatio
+            + components.battleRatio * weights.battleRatio
+            + components.honor * weights.honor
+        ) / weightSum
+        : 0;
+
+    let score = clamp(weightedCore * 0.82 + components.lifecycle * 0.18, 0, 100);
+    if (lifecycle === 'retired') {
+        score = Math.min(score, components.lifecycle);
+    }
+
+    score = Number(score.toFixed(2));
+    return {
+        score,
+        breakdown: {
+            ...components,
+            grade: buildGrade(score),
+        },
+    };
+}
+
+module.exports = {
+    toFiniteNumber,
+    clamp,
+    parseJsonArray,
+    safeRatio,
+    resolveModel,
+    buildGrade,
+    computeProxyValue,
+};

--- a/apps/proxy-pool-service/src/value-model.test.js
+++ b/apps/proxy-pool-service/src/value-model.test.js
@@ -1,0 +1,167 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const constants = require('./constants');
+const {
+    toFiniteNumber,
+    clamp,
+    parseJsonArray,
+    safeRatio,
+    resolveModel,
+    buildGrade,
+    computeProxyValue,
+} = require('./value-model');
+
+test('value-model helpers should cover numeric and json branches', () => {
+    assert.equal(toFiniteNumber('12.5', 0), 12.5);
+    assert.equal(toFiniteNumber('bad', 7), 7);
+    assert.equal(clamp(5, 0, 10), 5);
+    assert.equal(clamp(-1, 0, 10), 0);
+    assert.equal(clamp(11, 0, 10), 10);
+
+    assert.deepEqual(parseJsonArray(null), []);
+    assert.deepEqual(parseJsonArray([1, 2]), [1, 2]);
+    assert.deepEqual(parseJsonArray('["a"]'), ['a']);
+    assert.deepEqual(parseJsonArray('{}'), []);
+    assert.deepEqual(parseJsonArray('{bad'), []);
+
+    assert.equal(safeRatio(1, 2), 0.5);
+    assert.equal(safeRatio(5, 0), 0.5);
+    assert.equal(safeRatio(5, 2), 1);
+});
+
+test('resolveModel should merge custom weights and lifecycle map', () => {
+    const model = resolveModel({
+        valueModel: {
+            combatPointCap: 2000,
+            weights: {
+                combat: 50,
+            },
+            lifecycleScoreMap: {
+                reserve: 80,
+            },
+        },
+    });
+
+    assert.equal(model.combatPointCap, 2000);
+    assert.equal(model.weights.combat, 50);
+    assert.equal(model.weights.rank > 0, true);
+    assert.equal(model.lifecycleScoreMap.reserve, 80);
+    assert.equal(model.lifecycleScoreMap.active, 100);
+});
+
+test('buildGrade should map score to grade', () => {
+    assert.equal(buildGrade(90), 'S');
+    assert.equal(buildGrade(72), 'A');
+    assert.equal(buildGrade(56), 'B');
+    assert.equal(buildGrade(40), 'C');
+    assert.equal(buildGrade(39.9), 'D');
+});
+
+test('computeProxyValue should output score and breakdown with defaults', () => {
+    const proxy = {
+        rank: '士官',
+        combat_points: 300,
+        health_score: 85,
+        discipline_score: 88,
+        success_count: 80,
+        total_samples: 100,
+        battle_success_count: 30,
+        battle_fail_count: 10,
+        honor_history_json: JSON.stringify(['钢铁连胜', '逆风勇士']),
+        honor_active_json: JSON.stringify(['钢铁连胜']),
+        lifecycle: 'active',
+    };
+
+    const result = computeProxyValue(proxy, {});
+    assert.equal(result.score > 0, true);
+    assert.equal(result.score <= 100, true);
+    assert.equal(typeof result.breakdown.grade, 'string');
+    assert.equal(result.breakdown.successRatio, 80);
+    assert.equal(result.breakdown.battleRatio, 75);
+});
+
+test('computeProxyValue should handle retired branch and invalid config numbers', () => {
+    const proxy = {
+        rank: '未知军衔',
+        combat_points: 'bad',
+        health_score: null,
+        discipline_score: null,
+        success_count: 0,
+        total_samples: 0,
+        battle_success_count: 0,
+        battle_fail_count: 0,
+        honor_history_json: '{bad',
+        honor_active_json: '{}',
+        lifecycle: 'retired',
+    };
+    const result = computeProxyValue(proxy, {
+        valueModel: {
+            combatPointCap: 0,
+            honorActiveWeight: -5,
+            honorHistoryWeight: -7,
+            weights: {
+                rank: -10,
+                combat: 'bad',
+                health: -1,
+                discipline: -1,
+                successRatio: -1,
+                battleRatio: -1,
+                honor: -1,
+            },
+            lifecycleScoreMap: {
+                retired: 12,
+            },
+        },
+    });
+
+    assert.equal(result.score <= 12, true);
+    assert.equal(result.breakdown.lifecycle, 12);
+    assert.equal(result.breakdown.honor, 0);
+});
+
+test('computeProxyValue should cover fallback rank/lifecycle and zero-weight branch', () => {
+    const result = computeProxyValue(
+        {
+            rank: '',
+            lifecycle: '',
+            honor_history_json: '',
+            honor_active_json: '',
+        },
+        {
+            valueModel: {
+                weights: {
+                    rank: 0,
+                    combat: 0,
+                    health: 0,
+                    discipline: 0,
+                    successRatio: 0,
+                    battleRatio: 0,
+                    honor: 0,
+                },
+            },
+        },
+    );
+    assert.equal(result.score, 10.44);
+    assert.equal(result.breakdown.rank, 0);
+    assert.equal(result.breakdown.lifecycle, 58);
+});
+
+test('computeProxyValue should fallback unknown lifecycle to candidate score', () => {
+    const result = computeProxyValue(
+        {
+            rank: '新兵',
+            lifecycle: 'unknown',
+            combat_points: 10,
+        },
+        {},
+    );
+    assert.equal(result.breakdown.lifecycle, 58);
+});
+
+test('computeProxyValue should cover single-rank branch', () => {
+    const originalRanks = [...constants.RANKS];
+    constants.RANKS.splice(0, constants.RANKS.length, '单兵');
+    const result = computeProxyValue({ rank: '单兵', lifecycle: 'active' }, {});
+    assert.equal(result.breakdown.rank, 0);
+    constants.RANKS.splice(0, constants.RANKS.length, ...originalRanks);
+});

--- a/apps/proxy-pool-service/src/views/proxy-admin.html
+++ b/apps/proxy-pool-service/src/views/proxy-admin.html
@@ -67,6 +67,7 @@
 
     <section class="card"><h2>荣誉墙</h2><div class="content"><table id="honorTable"></table></div></section>
     <section class="card"><h2>退伍台账</h2><div class="content"><table id="retireTable"></table></div></section>
+    <section class="card"><h2>IP价值榜（前30）</h2><div class="content"><table id="valueTable"></table></div></section>
     <section class="card"><h2>事件流</h2><div class="content"><table id="eventTable"></table></div></section>
     <section class="card"><h2>代理明细（前50）</h2><div class="content"><table id="proxyTable"></table></div></section>
   </main>
@@ -79,6 +80,7 @@ const poolStats = document.getElementById('poolStats');
 const distributions = document.getElementById('distributions');
 const honorTable = document.getElementById('honorTable');
 const retireTable = document.getElementById('retireTable');
+const valueTable = document.getElementById('valueTable');
 const eventTable = document.getElementById('eventTable');
 const proxyTable = document.getElementById('proxyTable');
 
@@ -133,11 +135,12 @@ async function loadAll() {
     fetch('/v1/proxies/ranks/board').then(function(r){ return r.json(); }),
     fetch('/v1/proxies/honors?limit=30').then(function(r){ return r.json(); }),
     fetch('/v1/proxies/retirements?limit=30').then(function(r){ return r.json(); }),
+    fetch('/v1/proxies/value-board?limit=30').then(function(r){ return r.json(); }),
     fetch('/v1/proxies/events?limit=50').then(function(r){ return r.json(); }),
     fetch('/v1/proxies/list?limit=50').then(function(r){ return r.json(); }),
   ]);
 
-  const pool = data[0], ranks = data[1], honors = data[2], retires = data[3], events = data[4], proxies = data[5];
+  const pool = data[0], ranks = data[1], honors = data[2], retires = data[3], values = data[4], events = data[5], proxies = data[6];
   renderPool(pool.poolStatus);
   renderDistributions({ sourceDistribution: pool.sourceDistribution, lifecycleDistribution: pool.lifecycleDistribution, rankBoard: ranks.items });
 
@@ -149,12 +152,16 @@ async function loadAll() {
     return '<tr><td class="mono">' + esc(x.retired_at) + '</td><td>' + esc(x.display_name) + '</td><td class="warn">' + esc(x.retired_type) + '</td><td>' + esc(x.reason || '-') + '</td></tr>';
   }));
 
+  renderSimpleTable(valueTable, ['代理', '价值分', '军衔', '生命周期', '成功率', '战场胜率', '激活荣誉'], (values.items || []).map(function(x){
+    return '<tr><td>' + esc(x.display_name) + '</td><td class="ok">' + fmt(Number(x.ip_value_score || 0).toFixed(2)) + '</td><td>' + esc(x.rank) + '</td><td>' + esc(x.lifecycle) + '</td><td>' + fmt(Number((x.success_ratio || 0) * 100).toFixed(1)) + '%</td><td>' + fmt(Number((x.battle_ratio || 0) * 100).toFixed(1)) + '%</td><td>' + esc((x.honor_active || []).join(', ') || '-') + '</td></tr>';
+  }));
+
   renderSimpleTable(eventTable, ['时间', '类型', '代理', '消息'], (events.items || []).map(function(x){
     return '<tr><td class="mono">' + esc(x.timestamp) + '</td><td>' + esc(x.event_type) + '</td><td>' + esc(x.display_name || '-') + '</td><td>' + esc(x.message) + '</td></tr>';
   }));
 
-  renderSimpleTable(proxyTable, ['昵称', '地址', '来源', '生命周期', '军衔', '战功', '健康', '纪律', '样本'], (proxies.items || []).map(function(x){
-    return '<tr><td>' + esc(x.display_name) + '</td><td class="mono">' + esc(x.ip + ':' + x.port + '/' + x.protocol) + '</td><td>' + esc(x.source) + '</td><td>' + esc(x.lifecycle) + '</td><td>' + esc(x.rank) + '</td><td>' + fmt(x.combat_points) + '</td><td>' + fmt(x.health_score) + '</td><td>' + fmt(x.discipline_score) + '</td><td>' + fmt(x.total_samples) + '</td></tr>';
+  renderSimpleTable(proxyTable, ['昵称', '地址', '来源', '生命周期', '军衔', '价值分', '战功', '健康', '纪律', '样本'], (proxies.items || []).map(function(x){
+    return '<tr><td>' + esc(x.display_name) + '</td><td class="mono">' + esc(x.ip + ':' + x.port + '/' + x.protocol) + '</td><td>' + esc(x.source) + '</td><td>' + esc(x.lifecycle) + '</td><td>' + esc(x.rank) + '</td><td class="ok">' + fmt(Number(x.ip_value_score || 0).toFixed(2)) + '</td><td>' + fmt(x.combat_points) + '</td><td>' + fmt(x.health_score) + '</td><td>' + fmt(x.discipline_score) + '</td><td>' + fmt(x.total_samples) + '</td></tr>';
   }));
 }
 


### PR DESCRIPTION
## 变更摘要
- 新增可配置IP价值模型（军衔/战功/健康/纪律/成功率/战场胜率/荣誉/生命周期）并在评分与状态迁移中持续更新
- 新增策略热更新API：GET/POST /v1/proxies/policy，支持10h连续压测中动态调整晋升/退役/荣誉策略
- 新增价值榜API：GET /v1/proxies/value-board，并在管理台展示IP价值榜与价值分
- soak默认时长改为10h，并支持策略动作计划（SOAK_POLICY_ACTIONS_FILE），自动记录调参时间线与价值榜快照
- 补齐单元与集成测试，coverage门槛保持通过

## 验证
- npm run test:proxyhub:coverage
  - lines 100
  - branches 98.24
  - functions 100
  - statements 100

## 对应
- closes #24