### PR TITLE
feat(proxyhub): use stable L2 primary target for issue #27

### DIFF
--- a/apps/proxy-pool-service/src/config.js
+++ b/apps/proxy-pool-service/src/config.js
@@ -51,7 +51,10 @@
                 { name: 'ipify', url: 'https://api.ipify.org?format=json' },
             ],
             l2Primary: [
-                { name: 'ly-flight-main', url: 'https://www.ly.com/flights/itinerary/oneway/BJS-SYX?date=2026-04-01' },
+                {
+                    name: 'ly-flight-main',
+                    url: process.env.PROXY_HUB_BATTLE_L2_PRIMARY_URL || 'https://www.ly.com/flights/home',
+                },
             ],
             l2Fallback: [
                 { name: 'baidu-home', url: 'https://www.baidu.com' },

--- a/apps/proxy-pool-service/src/config.test.js
+++ b/apps/proxy-pool-service/src/config.test.js
@@ -1,8 +1,31 @@
-﻿const test = require('node:test');
+const test = require('node:test');
 const assert = require('node:assert/strict');
-const config = require('./config');
 
-test('config should expose required default values', () => {
+function loadConfigWithEnv(overrides = {}) {
+    const key = 'PROXY_HUB_BATTLE_L2_PRIMARY_URL';
+    const original = process.env[key];
+
+    if (Object.prototype.hasOwnProperty.call(overrides, key)) {
+        process.env[key] = overrides[key];
+    } else {
+        delete process.env[key];
+    }
+
+    const modulePath = require.resolve('./config');
+    delete require.cache[modulePath];
+    const config = require('./config');
+
+    if (original == null) {
+        delete process.env[key];
+    } else {
+        process.env[key] = original;
+    }
+    delete require.cache[modulePath];
+    return config;
+}
+
+test('config should expose required default values', { concurrency: false }, () => {
+    const config = loadConfigWithEnv();
     assert.equal(config.service.name, 'ProxyHub');
     assert.equal(config.service.port, 5070);
     assert.equal(config.service.timezone, 'Asia/Shanghai');
@@ -17,13 +40,23 @@ test('config should expose required default values', () => {
     assert.equal(config.battle.maxBattleL2PerCycle, 20);
     assert.equal(config.battle.candidateQuota, 0.15);
     assert.equal(Array.isArray(config.battle.targets.l1), true);
+    assert.equal(config.battle.targets.l2Primary[0].name, 'ly-flight-main');
+    assert.equal(config.battle.targets.l2Primary[0].url, 'https://www.ly.com/flights/home');
 });
 
-test('config ranks should be ordered and complete', () => {
+test('config ranks should be ordered and complete', { concurrency: false }, () => {
+    const config = loadConfigWithEnv();
     const ranks = config.policy.ranks.map((item) => item.rank);
     assert.deepEqual(ranks, ['新兵', '列兵', '士官', '尉官', '王牌']);
     assert.equal(config.policy.promotionProtectHours, 6);
     assert.equal(config.policy.valueModel.combatPointCap, 1200);
     assert.equal(config.policy.valueModel.lifecycleScoreMap.retired, 8);
     assert.equal(config.soak.durationHours, 10);
+});
+
+test('config should support env override for L2 primary target', { concurrency: false }, () => {
+    const config = loadConfigWithEnv({
+        PROXY_HUB_BATTLE_L2_PRIMARY_URL: 'https://example.com/l2-primary',
+    });
+    assert.equal(config.battle.targets.l2Primary[0].url, 'https://example.com/l2-primary');
 });

--- a/apps/proxy-pool-service/src/worker.test.js
+++ b/apps/proxy-pool-service/src/worker.test.js
@@ -439,6 +439,8 @@ test('battle L2 task should classify blocked/network_error/success branches', as
         ]),
     });
     assert.equal(network.outcome, 'network_error');
+    assert.equal(network.runs[1].outcome, 'success');
+    assert.equal(network.runs[1].reason, 'fallback_ok');
 
     const success = await runBattleL2Task({
         proxy: { protocol: 'http', ip: '1.1.1.1', port: 80 },

--- a/docs/18_issue27_l2_primary_target_strategy_20260316.md
+++ b/docs/18_issue27_l2_primary_target_strategy_20260316.md
@@ -1,0 +1,17 @@
+# Issue #27 对策落地说明（2026-03-16）
+
+## 锁定策略
+1. L2 主目标改为稳定业务入口：`https://www.ly.com/flights/home`。
+2. 保留目标名称：`ly-flight-main`（保持历史报表口径连续）。
+3. 保留 fallback：`baidu-home`，仅用于兜底诊断，不覆盖主目标判定。
+
+## 为什么不用 `https://www.ly.com/`
+1. L2 目标是验证机票业务可用性，不是门户首页可达性。
+2. 根域首页可能可访问，但机票业务链路异常，容易形成假阳性。
+3. `flights/home` 不依赖固定日期参数，长期稳定性和可比性更好。
+4. 现有 L2 断言关键词（`flight/航班/机票`）与机票频道入口更匹配。
+
+## 配置与兼容
+1. 默认 L2 主目标：`https://www.ly.com/flights/home`。
+2. 支持环境变量覆盖：`PROXY_HUB_BATTLE_L2_PRIMARY_URL`。
+3. `fallback` 成功不会把主目标失败改判为 `success`。


### PR DESCRIPTION
## Summary
- switch L2 primary target default from fixed itinerary URL to stable flight entry `https://www.ly.com/flights/home`
- add env override `PROXY_HUB_BATTLE_L2_PRIMARY_URL`
- keep `ly-flight-main` naming for report continuity
- keep fallback semantics: `baidu-home` is diagnostics only and does not override primary outcome
- add issue strategy doc for #27

## Why not use https://www.ly.com/
- root homepage reachability is weaker than flight-business reachability for L2 goals
- homepage may pass while flight path is degraded (false positives)
- `flights/home` keeps business relevance while avoiding fixed-date volatility

## Test
- `npm.cmd run test:proxyhub:unit`

Closes #27