### PR TITLE
fix(proxyhub): 修复 #16 运行时日志中文化与历史回填

### DIFF
--- a/apps/proxy-pool-service/src/engine.js
+++ b/apps/proxy-pool-service/src/engine.js
@@ -45,10 +45,10 @@ async function runWithConcurrency(items, limit, handler) {
 // 0025_outcomeLabel_结果标签逻辑
 function outcomeLabel(outcome) {
     if (outcome === 'success') return '成功';
-    if (outcome === 'blocked') return 'blocked';
-    if (outcome === 'timeout') return 'timeout';
-    if (outcome === 'network_error') return 'networkError';
-    if (outcome === 'invalid_feedback') return 'invalidFeedback';
+    if (outcome === 'blocked') return '封禁';
+    if (outcome === 'timeout') return '超时';
+    if (outcome === 'network_error') return '网络错误';
+    if (outcome === 'invalid_feedback') return '反馈无效';
     return '未知';
 }
 

--- a/apps/proxy-pool-service/src/engine.test.js
+++ b/apps/proxy-pool-service/src/engine.test.js
@@ -117,10 +117,10 @@ test('engine utility functions should cover helper branches', async () => {
     assert.deepEqual(parseArrayJson('{}'), []);
     assert.deepEqual(parseArrayJson('{bad'), []);
     assert.equal(outcomeLabel('success'), '成功');
-    assert.equal(outcomeLabel('blocked'), 'blocked');
-    assert.equal(outcomeLabel('timeout'), 'timeout');
-    assert.equal(outcomeLabel('network_error'), 'networkError');
-    assert.equal(outcomeLabel('invalid_feedback'), 'invalidFeedback');
+    assert.equal(outcomeLabel('blocked'), '封禁');
+    assert.equal(outcomeLabel('timeout'), '超时');
+    assert.equal(outcomeLabel('network_error'), '网络错误');
+    assert.equal(outcomeLabel('invalid_feedback'), '反馈无效');
     assert.equal(outcomeLabel('other'), '未知');
 
     assert.equal(mapEventTypeToChinese('promotion'), '晋升');

--- a/apps/proxy-pool-service/src/logger.js
+++ b/apps/proxy-pool-service/src/logger.js
@@ -1,4 +1,94 @@
-﻿const { EventEmitter } = require('node:events');
+const { EventEmitter } = require('node:events');
+
+const EXACT_TRANSLATIONS = {
+    success: '成功',
+    blocked: '封禁',
+    timeout: '超时',
+    network_error: '网络错误',
+    networkerror: '网络错误',
+    invalid_feedback: '反馈无效',
+    invalidfeedback: '反馈无效',
+    candidate: '候选',
+    active: '现役',
+    reserve: '预备',
+    retired: '退役',
+};
+
+const TOKEN_TRANSLATIONS = {
+    invalid_feedback: '反馈无效',
+    invalidFeedback: '反馈无效',
+    network_error: '网络错误',
+    networkError: '网络错误',
+    success: '成功',
+    blocked: '封禁',
+    timeout: '超时',
+    candidate: '候选',
+    active: '现役',
+    reserve: '预备',
+    retired: '退役',
+};
+
+// 0218_escapeRegExp_转义正则字符逻辑
+function escapeRegExp(input) {
+    return String(input).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// 0219_localizeRuntimeText_本地化运行时文本逻辑
+function localizeRuntimeText(value) {
+    if (value == null) {
+        return '-';
+    }
+
+    const raw = String(value).trim();
+    if (!raw) {
+        return '-';
+    }
+
+    const exactKey = raw.toLowerCase().replace(/\s+/g, '');
+    if (Object.prototype.hasOwnProperty.call(EXACT_TRANSLATIONS, exactKey)) {
+        return EXACT_TRANSLATIONS[exactKey];
+    }
+
+    let localized = raw;
+    for (const [token, replacement] of Object.entries(TOKEN_TRANSLATIONS)) {
+        const pattern = new RegExp(`\\b${escapeRegExp(token)}\\b`, 'gi');
+        localized = localized.replace(pattern, replacement);
+    }
+    return localized;
+}
+
+// 0220_normalizeRuntimeDetails_归一化日志详情逻辑
+function normalizeRuntimeDetails(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return {};
+    }
+    return { ...value };
+}
+
+// 0221_localizeRuntimeRecord_本地化运行时日志记录逻辑
+function localizeRuntimeRecord(record) {
+    const details = normalizeRuntimeDetails(record?.details);
+
+    const rawResult = record?.result || '-';
+    const rawReason = record?.reason || '-';
+    const rawAction = record?.action || '-';
+
+    const result = localizeRuntimeText(rawResult);
+    const reason = localizeRuntimeText(rawReason);
+    const action = localizeRuntimeText(rawAction);
+
+    if (result !== rawResult && !Object.prototype.hasOwnProperty.call(details, 'raw_result')) {
+        details.raw_result = rawResult;
+    }
+    if (reason !== rawReason && !Object.prototype.hasOwnProperty.call(details, 'raw_reason')) {
+        details.raw_reason = rawReason;
+    }
+    if (action !== rawAction && !Object.prototype.hasOwnProperty.call(details, 'raw_action')) {
+        details.raw_action = rawAction;
+    }
+
+    return { result, reason, action, details };
+}
 
 class RuntimeLogger extends EventEmitter {
     // 0190_constructor_初始化实例逻辑
@@ -11,17 +101,18 @@ class RuntimeLogger extends EventEmitter {
 
     // 0071_write_写入逻辑
     write(record) {
+        const localized = localizeRuntimeRecord(record);
         const entry = {
             timestamp: record.timestamp || new Date().toISOString(),
             event: record.event || '系统事件',
             proxy_name: record.proxyName || '-',
             ip_source: record.ipSource || '-',
             stage: record.stage || '-',
-            result: record.result || '-',
+            result: localized.result,
             duration_ms: Number.isFinite(record.durationMs) ? Math.round(record.durationMs) : null,
-            reason: record.reason || '-',
-            action: record.action || '-',
-            details: record.details || {},
+            reason: localized.reason,
+            action: localized.action,
+            details: localized.details,
         };
 
         this.logs.push(entry);
@@ -54,4 +145,6 @@ class RuntimeLogger extends EventEmitter {
 
 module.exports = {
     RuntimeLogger,
+    localizeRuntimeText,
+    localizeRuntimeRecord,
 };

--- a/apps/proxy-pool-service/src/logger.test.js
+++ b/apps/proxy-pool-service/src/logger.test.js
@@ -1,6 +1,6 @@
 ﻿const test = require('node:test');
 const assert = require('node:assert/strict');
-const { RuntimeLogger } = require('./logger');
+const { RuntimeLogger, localizeRuntimeText, localizeRuntimeRecord } = require('./logger');
 
 // 0073_createDbStub_创建逻辑
 function createDbStub(throwOnInsert = false) {
@@ -77,4 +77,57 @@ test('logger should fallback to default event name when absent', () => {
     const logger = new RuntimeLogger({ db, retention: 2 });
     const entry = logger.write({});
     assert.equal(entry.event, '系统事件');
+});
+
+test('localizeRuntimeText should map known tokens and lifecycle labels', () => {
+    assert.equal(localizeRuntimeText('success'), '成功');
+    assert.equal(localizeRuntimeText('blocked'), '封禁');
+    assert.equal(localizeRuntimeText('timeout'), '超时');
+    assert.equal(localizeRuntimeText('network_error'), '网络错误');
+    assert.equal(localizeRuntimeText('networkError'), '网络错误');
+    assert.equal(localizeRuntimeText('invalid_feedback'), '反馈无效');
+    assert.equal(localizeRuntimeText('invalidFeedback'), '反馈无效');
+    assert.equal(localizeRuntimeText('active'), '现役');
+    assert.equal(localizeRuntimeText('新兵/active'), '新兵/现役');
+    assert.equal(localizeRuntimeText(' candidate '), '候选');
+    assert.equal(localizeRuntimeText(null), '-');
+    assert.equal(localizeRuntimeText(''), '-');
+});
+
+test('localizeRuntimeRecord should inject raw fields into details when localized', () => {
+    const localized = localizeRuntimeRecord({
+        result: 'network_error',
+        reason: '新兵/active',
+        action: 'wait for timeout',
+        details: { traceId: 'x-1' },
+    });
+
+    assert.equal(localized.result, '网络错误');
+    assert.equal(localized.reason, '新兵/现役');
+    assert.equal(localized.action, 'wait for 超时');
+    assert.equal(localized.details.traceId, 'x-1');
+    assert.equal(localized.details.raw_result, 'network_error');
+    assert.equal(localized.details.raw_reason, '新兵/active');
+    assert.equal(localized.details.raw_action, 'wait for timeout');
+});
+
+test('logger should normalize record fields to chinese and preserve raw values in details', () => {
+    const db = createDbStub(false);
+    const logger = new RuntimeLogger({ db, retention: 2 });
+
+    const entry = logger.write({
+        event: '写数据库成功',
+        result: 'blocked',
+        reason: '列兵/reserve',
+        action: 'retry after timeout',
+        details: 'not-object',
+    });
+
+    assert.equal(entry.result, '封禁');
+    assert.equal(entry.reason, '列兵/预备');
+    assert.equal(entry.action, 'retry after 超时');
+    assert.equal(entry.details.raw_result, 'blocked');
+    assert.equal(entry.details.raw_reason, '列兵/reserve');
+    assert.equal(entry.details.raw_action, 'retry after timeout');
+    assert.equal(db.logs[0].details.raw_result, 'blocked');
 });

--- a/apps/proxy-pool-service/src/migrate-runtime-log-localization.js
+++ b/apps/proxy-pool-service/src/migrate-runtime-log-localization.js
@@ -1,0 +1,181 @@
+const config = require('./config');
+const { ProxyHubDb } = require('./db');
+const { localizeRuntimeText } = require('./logger');
+
+// 0222_parseArgs_解析命令参数逻辑
+function parseArgs(argv) {
+    const args = Array.isArray(argv) ? argv : [];
+    let dryRun = true;
+    let sample = 20;
+    let limit = 0;
+
+    for (let i = 0; i < args.length; i += 1) {
+        const arg = args[i];
+        if (arg === '--apply') {
+            dryRun = false;
+            continue;
+        }
+        if (arg === '--dry-run') {
+            dryRun = true;
+            continue;
+        }
+        if (arg === '--sample') {
+            const value = Number(args[i + 1]);
+            if (!Number.isFinite(value) || value <= 0) {
+                throw new Error('invalid-sample-value');
+            }
+            sample = Math.max(1, Math.min(200, Math.floor(value)));
+            i += 1;
+            continue;
+        }
+        if (arg === '--limit') {
+            const value = Number(args[i + 1]);
+            if (!Number.isFinite(value) || value < 0) {
+                throw new Error('invalid-limit-value');
+            }
+            limit = Math.floor(value);
+            i += 1;
+            continue;
+        }
+        throw new Error(`unknown-arg:${arg}`);
+    }
+
+    return { dryRun, sample, limit };
+}
+
+// 0223_parseDetailsJson_解析日志详情JSON逻辑
+function parseDetailsJson(raw) {
+    try {
+        if (!raw) return {};
+        const parsed = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            return {};
+        }
+        return parsed;
+    } catch {
+        return {};
+    }
+}
+
+// 0224_buildLocalizedRow_构建本地化行数据逻辑
+function buildLocalizedRow(row) {
+    const rawResult = row.result || '-';
+    const rawReason = row.reason || '-';
+    const rawAction = row.action || '-';
+
+    const result = localizeRuntimeText(rawResult);
+    const reason = localizeRuntimeText(rawReason);
+    const action = localizeRuntimeText(rawAction);
+
+    const changed = result !== rawResult || reason !== rawReason || action !== rawAction;
+    if (!changed) {
+        return null;
+    }
+
+    const details = parseDetailsJson(row.details_json);
+    if (result !== rawResult && !Object.prototype.hasOwnProperty.call(details, 'raw_result')) {
+        details.raw_result = rawResult;
+    }
+    if (reason !== rawReason && !Object.prototype.hasOwnProperty.call(details, 'raw_reason')) {
+        details.raw_reason = rawReason;
+    }
+    if (action !== rawAction && !Object.prototype.hasOwnProperty.call(details, 'raw_action')) {
+        details.raw_action = rawAction;
+    }
+
+    return {
+        id: row.id,
+        result,
+        reason,
+        action,
+        details_json: JSON.stringify(details),
+        before: { result: rawResult, reason: rawReason, action: rawAction },
+        after: { result, reason, action },
+    };
+}
+
+// 0225_runMigration_执行日志本地化迁移逻辑
+function runMigration(options = {}) {
+    const db = options.db || new ProxyHubDb(config);
+    const parsed = parseArgs(options.argv || process.argv.slice(2));
+    const startedAt = Date.now();
+
+    try {
+        const rows = parsed.limit > 0
+            ? db.db.prepare(`
+                SELECT id, result, reason, action, details_json
+                FROM runtime_logs
+                ORDER BY id ASC
+                LIMIT ?
+            `).all(parsed.limit)
+            : db.db.prepare(`
+                SELECT id, result, reason, action, details_json
+                FROM runtime_logs
+                ORDER BY id ASC
+            `).all();
+
+        const changedRows = [];
+        for (const row of rows) {
+            const localized = buildLocalizedRow(row);
+            if (localized) {
+                changedRows.push(localized);
+            }
+        }
+
+        if (!parsed.dryRun && changedRows.length > 0) {
+            const updateStmt = db.db.prepare(`
+                UPDATE runtime_logs
+                SET result = @result, reason = @reason, action = @action, details_json = @details_json
+                WHERE id = @id
+            `);
+            const tx = db.db.transaction((items) => {
+                for (const item of items) {
+                    updateStmt.run(item);
+                }
+            });
+            tx(changedRows);
+        }
+
+        return {
+            ok: true,
+            result: {
+                dryRun: parsed.dryRun,
+                limit: parsed.limit,
+                total: rows.length,
+                changed: changedRows.length,
+                updated: parsed.dryRun ? 0 : changedRows.length,
+                sample: changedRows.slice(0, parsed.sample).map((item) => ({
+                    id: item.id,
+                    before: item.before,
+                    after: item.after,
+                })),
+                durationMs: Date.now() - startedAt,
+            },
+        };
+    } catch (error) {
+        return {
+            ok: false,
+            error: error?.message || String(error),
+        };
+    } finally {
+        if (!options.db) {
+            db.close();
+        }
+    }
+}
+
+/* c8 ignore next 7 */
+if (require.main === module) {
+    const outcome = runMigration();
+    console.log(JSON.stringify(outcome, null, 2));
+    if (!outcome.ok) {
+        process.exit(1);
+    }
+}
+
+module.exports = {
+    parseArgs,
+    parseDetailsJson,
+    buildLocalizedRow,
+    runMigration,
+};

--- a/apps/proxy-pool-service/src/migrate-runtime-log-localization.test.js
+++ b/apps/proxy-pool-service/src/migrate-runtime-log-localization.test.js
@@ -1,0 +1,270 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const config = require('./config');
+const { ProxyHubDb } = require('./db');
+const {
+    parseArgs,
+    parseDetailsJson,
+    buildLocalizedRow,
+    runMigration,
+} = require('./migrate-runtime-log-localization');
+
+// 0226_createDb_创建运行时日志迁移测试数据库逻辑
+function createDb() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'proxyhub-log-localize-'));
+    const dbPath = path.join(dir, 'runtime-log-localize.db');
+    const db = new ProxyHubDb({
+        storage: {
+            dbPath,
+            snapshotRetentionDays: 7,
+        },
+    });
+    return { dir, db, dbPath };
+}
+
+// 0227_cleanup_清理运行时日志迁移测试数据库逻辑
+function cleanup(handle) {
+    handle.db.close();
+    fs.rmSync(handle.dir, { recursive: true, force: true });
+}
+
+test('parseArgs should parse apply dry-run sample and limit flags', () => {
+    assert.deepEqual(parseArgs([]), { dryRun: true, sample: 20, limit: 0 });
+    assert.deepEqual(parseArgs('not-array'), { dryRun: true, sample: 20, limit: 0 });
+    assert.deepEqual(parseArgs(['--apply']), { dryRun: false, sample: 20, limit: 0 });
+    assert.deepEqual(parseArgs(['--apply', '--sample', '8', '--limit', '99']), { dryRun: false, sample: 8, limit: 99 });
+    assert.deepEqual(parseArgs(['--sample', '999']), { dryRun: true, sample: 200, limit: 0 });
+    assert.throws(() => parseArgs(['--sample', '0']), /invalid-sample-value/);
+    assert.throws(() => parseArgs(['--limit', '-1']), /invalid-limit-value/);
+    assert.throws(() => parseArgs(['--unknown']), /unknown-arg/);
+});
+
+test('parseDetailsJson should parse object and fallback for invalid values', () => {
+    assert.deepEqual(parseDetailsJson(null), {});
+    assert.deepEqual(parseDetailsJson(''), {});
+    assert.deepEqual(parseDetailsJson('{"a":1}'), { a: 1 });
+    assert.deepEqual(parseDetailsJson('[]'), {});
+    assert.deepEqual(parseDetailsJson('{bad'), {});
+});
+
+test('buildLocalizedRow should return null when no localization is needed', () => {
+    const localized = buildLocalizedRow({
+        id: 1,
+        result: '成功',
+        reason: '正常',
+        action: '继续',
+        details_json: '{}',
+    });
+    assert.equal(localized, null);
+});
+
+test('buildLocalizedRow should localize fields and preserve original values in details', () => {
+    const localized = buildLocalizedRow({
+        id: 2,
+        result: 'network_error',
+        reason: '列兵/active',
+        action: 'wait for timeout',
+        details_json: '{"trace":"x","raw_reason":"old"}',
+    });
+
+    assert.equal(localized.id, 2);
+    assert.equal(localized.result, '网络错误');
+    assert.equal(localized.reason, '列兵/现役');
+    assert.equal(localized.action, 'wait for 超时');
+    const details = JSON.parse(localized.details_json);
+    assert.equal(details.trace, 'x');
+    assert.equal(details.raw_result, 'network_error');
+    assert.equal(details.raw_reason, 'old');
+    assert.equal(details.raw_action, 'wait for timeout');
+});
+
+test('buildLocalizedRow should fallback empty fields to dash and only record changed raw fields', () => {
+    const localized = buildLocalizedRow({
+        id: 3,
+        result: 'blocked',
+        reason: '',
+        action: null,
+        details_json: '{}',
+    });
+
+    assert.equal(localized.result, '封禁');
+    assert.equal(localized.reason, '-');
+    assert.equal(localized.action, '-');
+    const details = JSON.parse(localized.details_json);
+    assert.equal(details.raw_result, 'blocked');
+    assert.equal(Object.prototype.hasOwnProperty.call(details, 'raw_reason'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(details, 'raw_action'), false);
+});
+
+test('runMigration should support dry-run and apply modes', () => {
+    const h = createDb();
+    const now = new Date().toISOString();
+    h.db.insertRuntimeLog({
+        timestamp: now,
+        event: '测试一',
+        proxy_name: 'A',
+        ip_source: 'src',
+        stage: '评分',
+        result: 'timeout',
+        reason: '列兵/active',
+        action: 'wait for timeout',
+        details: { traceId: 't-1' },
+    });
+    h.db.insertRuntimeLog({
+        timestamp: now,
+        event: '测试二',
+        proxy_name: 'B',
+        ip_source: 'src',
+        stage: '评分',
+        result: '成功',
+        reason: '-',
+        action: '-',
+        details: {},
+    });
+
+    const preview = runMigration({
+        db: h.db,
+        argv: ['--dry-run', '--sample', '2', '--limit', '10'],
+    });
+    assert.equal(preview.ok, true);
+    assert.equal(preview.result.dryRun, true);
+    assert.equal(preview.result.total, 2);
+    assert.equal(preview.result.changed, 1);
+    assert.equal(preview.result.updated, 0);
+    assert.equal(preview.result.sample.length, 1);
+
+    const applied = runMigration({
+        db: h.db,
+        argv: ['--apply', '--sample', '1'],
+    });
+    assert.equal(applied.ok, true);
+    assert.equal(applied.result.dryRun, false);
+    assert.equal(applied.result.changed, 1);
+    assert.equal(applied.result.updated, 1);
+    assert.equal(applied.result.sample.length, 1);
+
+    const row = h.db.db.prepare('SELECT result, reason, action, details_json FROM runtime_logs WHERE event = ?').get('测试一');
+    const details = JSON.parse(row.details_json);
+    assert.equal(row.result, '超时');
+    assert.equal(row.reason, '列兵/现役');
+    assert.equal(row.action, 'wait for 超时');
+    assert.equal(details.raw_result, 'timeout');
+    assert.equal(details.raw_reason, '列兵/active');
+    assert.equal(details.raw_action, 'wait for timeout');
+
+    cleanup(h);
+});
+
+test('runMigration should return failure payload when database throws without message', () => {
+    const fakeDb = {
+        db: {
+            prepare() {
+                throw null;
+            },
+        },
+    };
+
+    const result = runMigration({
+        db: fakeDb,
+        argv: ['--apply'],
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.error, 'null');
+});
+
+test('runMigration should return failure payload with error message', () => {
+    const fakeDb = {
+        db: {
+            prepare() {
+                throw new Error('db-boom');
+            },
+        },
+    };
+
+    const result = runMigration({
+        db: fakeDb,
+        argv: ['--apply'],
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.error, 'db-boom');
+});
+
+test('runMigration should parse arguments from process argv when argv is not provided', () => {
+    const h = createDb();
+    const now = new Date().toISOString();
+    h.db.insertRuntimeLog({
+        timestamp: now,
+        event: 'process-argv',
+        proxy_name: 'P',
+        ip_source: 'src',
+        stage: '评分',
+        result: 'timeout',
+        reason: '-',
+        action: '-',
+        details: {},
+    });
+
+    const originalArgv = process.argv;
+    process.argv = [process.execPath, 'migrate-runtime-log-localization.js', '--dry-run', '--limit', '1'];
+    try {
+        const result = runMigration({ db: h.db });
+        assert.equal(result.ok, true);
+        assert.equal(result.result.total, 1);
+        assert.equal(result.result.limit, 1);
+    } finally {
+        process.argv = originalArgv;
+        cleanup(h);
+    }
+});
+
+test('runMigration apply should skip updates when there is no changed row', () => {
+    const h = createDb();
+    const now = new Date().toISOString();
+    h.db.insertRuntimeLog({
+        timestamp: now,
+        event: 'already-cn',
+        proxy_name: 'C',
+        ip_source: 'src',
+        stage: '评分',
+        result: '成功',
+        reason: '正常',
+        action: '继续',
+        details: {},
+    });
+
+    const result = runMigration({
+        db: h.db,
+        argv: ['--apply'],
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.result.changed, 0);
+    assert.equal(result.result.updated, 0);
+
+    cleanup(h);
+});
+
+test('runMigration should close internally created db when db is not injected', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'proxyhub-log-localize-run-'));
+    const dbPath = path.join(tempDir, 'runtime-log-localize-run.db');
+    const previousDbPath = config.storage.dbPath;
+    config.storage.dbPath = dbPath;
+
+    try {
+        const result = runMigration({
+            argv: ['--dry-run', '--limit', '0'],
+        });
+        assert.equal(result.ok, true);
+        assert.equal(result.result.dryRun, true);
+        assert.equal(fs.existsSync(dbPath), true);
+    } finally {
+        config.storage.dbPath = previousDbPath;
+        try {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        } catch {
+            // ignore windows sqlite lock cleanup races
+        }
+    }
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "soak:v1": "node apps/proxy-pool-service/src/soak.js",
     "watch:soak": "node apps/proxy-pool-service/src/soak-watchdog-v2.js",
     "migrate:proxyhub:names": "node apps/proxy-pool-service/src/migrate-display-names.js",
+    "migrate:proxyhub:runtime-logs": "node apps/proxy-pool-service/src/migrate-runtime-log-localization.js",
     "test:proxyhub": "node --test apps/proxy-pool-service/src/**/*.test.js apps/proxy-pool-service/tests/**/*.integration.test.js",
     "test:proxyhub:unit": "node --test apps/proxy-pool-service/src/**/*.test.js",
     "test:proxyhub:integration": "node --test apps/proxy-pool-service/tests/**/*.integration.test.js",


### PR DESCRIPTION
## 背景\nIssue #16 指出 runtime_logs 中 result/reason/action 仍混有英文字段，影响中文实时读数。\n\n## 变更内容\n- 将运行时日志 esult/reason/action 统一本地化为中文\n- 保留原始机器值到 details.raw_result/raw_reason/raw_action\n- 修正 engine.outcomeLabel 的英文输出\n- 新增一次性回填脚本：migrate-runtime-log-localization.js（支持 dry-run/apply）\n- 增加对应单测并覆盖回填分支\n\n## 验证\n- 
pm run test:proxyhub:unit\n- 
pm run test:proxyhub:coverage（branches 98.11% >= 98%）\n- 对 proxyhub-v1.db 执行 --apply 回填后，英文 outcome/lifecycle token 计数为 0\n\nCloses #16