### PR TITLE
fix(proxyhub): avoid post-shutdown snapshot DB access race (#12)

### DIFF
--- a/apps/proxy-pool-service/src/server.js
+++ b/apps/proxy-pool-service/src/server.js
@@ -237,6 +237,7 @@ function createRuntime(options = {}) {
     });
 
     let server;
+    let engineStartPromise = null;
 
     // 0094_start_启动逻辑
     async function start() {
@@ -256,15 +257,20 @@ function createRuntime(options = {}) {
                         action: '可访问 /proxy-admin 和 /runtime/logs',
                     });
 
-                    void engine.start().catch((error) => {
-                        logger.write({
-                            event: '线程池告警',
-                            stage: '启动',
-                            result: '引擎启动失败',
-                            reason: error?.message || 'unknown',
-                            action: '保持服务在线并等待下次启动',
+                    engineStartPromise = Promise.resolve()
+                        .then(() => engine.start())
+                        .catch((error) => {
+                            logger.write({
+                                event: '线程池告警',
+                                stage: '启动',
+                                result: '引擎启动失败',
+                                reason: error?.message || 'unknown',
+                                action: '保持服务在线并等待下次启动',
+                            });
+                        })
+                        .finally(() => {
+                            engineStartPromise = null;
                         });
-                    });
 
                     resolve(server);
                 });
@@ -290,6 +296,10 @@ function createRuntime(options = {}) {
             server = null;
         }
 
+        await engine.stop();
+        if (engineStartPromise) {
+            await engineStartPromise;
+        }
         await engine.stop();
         await workerPool.close();
         db.close();

--- a/apps/proxy-pool-service/src/server.test.js
+++ b/apps/proxy-pool-service/src/server.test.js
@@ -57,7 +57,7 @@ function createConfig(port = 0) {
 function createStubs() {
     const loggerEvents = new EventEmitter();
     const poolEvents = new EventEmitter();
-    const state = { dbClosed: false, poolClosed: false, engineStarted: false, engineStopped: false };
+    const state = { dbClosed: false, poolClosed: false, engineStarted: false, engineStopped: false, engineStopCalls: 0 };
 
     const db = {
         getSourceDistribution: () => [{ source: 'monosans', count: 2 }],
@@ -109,6 +109,7 @@ function createStubs() {
     };
     engine.stop = async () => {
         state.engineStopped = true;
+        state.engineStopCalls += 1;
     };
 
     return { db, logger, workerPool, engine, state };
@@ -206,6 +207,34 @@ test('server runtime should expose all REST endpoints and shutdown cleanly', asy
     assert.equal(stubs.state.dbClosed, true);
     assert.equal(stubs.state.poolClosed, true);
     assert.equal(stubs.state.engineStopped, true);
+});
+
+test('shutdown should wait for in-flight engine start before closing db', async () => {
+    const stubs = createStubs();
+    let releaseStart;
+    const startGate = new Promise((resolve) => {
+        releaseStart = resolve;
+    });
+    stubs.engine.start = async () => {
+        stubs.state.engineStarted = true;
+        await startGate;
+    };
+
+    const { runtime } = await startRuntimeOnRandomPort(stubs);
+    const shutdownPromise = runtime.shutdown('RACE');
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    assert.equal(stubs.state.engineStarted, true);
+    assert.equal(stubs.state.engineStopCalls >= 1, true);
+    assert.equal(stubs.state.dbClosed, false);
+    assert.equal(stubs.state.poolClosed, false);
+
+    releaseStart();
+    await shutdownPromise;
+
+    assert.equal(stubs.state.dbClosed, true);
+    assert.equal(stubs.state.poolClosed, true);
+    assert.equal(stubs.state.engineStopCalls >= 2, true);
 });
 
 test('server start should reject when listen emits error', async () => {


### PR DESCRIPTION
## Summary
- 修复 `runtime.shutdown()` 与异步 `engine.start()` 并发时的竞态
- 关键点：shutdown 现在会等待 in-flight `engine.start()` 结束，再执行最终 `engine.stop()`，随后再关 workerPool/DB
- 这样可避免 `engine.start()` 在 shutdown 之后补建定时器，导致后续快照周期访问已关闭数据库

## Changes
- `apps/proxy-pool-service/src/server.js`
  - 新增 `engineStartPromise` 跟踪启动中的引擎任务
  - `start()` 中将 `engine.start()` 包装为可等待 Promise
  - `shutdown()` 顺序改为：先 `engine.stop()` -> 等待 `engineStartPromise`（若存在）-> 再 `engine.stop()` -> 关闭 workerPool 与 DB
- `apps/proxy-pool-service/src/server.test.js`
  - 新增竞态单测：`shutdown should wait for in-flight engine start before closing db`
  - 验证 shutdown 在 engine.start 未完成时不会提前关库，并最终完成二次 stop 清理

## Validation
- `node --test apps/proxy-pool-service/src/server.test.js`
- `npm.cmd run test:proxyhub:unit`
- `npm.cmd run test:proxyhub:coverage`

Closes #12