### PR TITLE
feat(proxyhub): expand rank ladder and honor criteria (issue #45)

### DIFF
--- a/apps/proxy-pool-service/src/config.js
+++ b/apps/proxy-pool-service/src/config.js
@@ -17,13 +17,19 @@ const legacyRanks = [
     { rank: '列兵', minHours: 12, minPoints: 80, minSamples: 20 },
     { rank: '士官', minHours: 24, minPoints: 220, minSamples: 60 },
     { rank: '尉官', minHours: 48, minPoints: 520, minSamples: 140 },
-    { rank: '王牌', minHours: 72, minPoints: 980, minSamples: 260 },
+    { rank: '校官', minHours: 56, minPoints: 680, minSamples: 180 },
+    { rank: '将官', minHours: 68, minPoints: 860, minSamples: 250 },
+    { rank: '王牌', minHours: 84, minPoints: 1080, minSamples: 320 },
 ];
 
 const legacyHonors = {
     steelStreak: 30,
     riskyWarrior: 20,
     thousandService: 1000,
+    l2Mastery: 180,
+    disciplineGuardMinScore: 92,
+    disciplineGuardMaxInvalid: 2,
+    disciplineGuardMinSamples: 300,
     riskyFailRatioThreshold: 0.35,
 };
 
@@ -111,12 +117,18 @@ const policyProfiles = {
             { rank: '列兵', minHours: 10, minPoints: 60, minSamples: 20 },
             { rank: '士官', minHours: 22, minPoints: 180, minSamples: 70 },
             { rank: '尉官', minHours: 44, minPoints: 430, minSamples: 180 },
-            { rank: '王牌', minHours: 70, minPoints: 860, minSamples: 320 },
+            { rank: '校官', minHours: 52, minPoints: 560, minSamples: 220 },
+            { rank: '将官', minHours: 64, minPoints: 760, minSamples: 290 },
+            { rank: '王牌', minHours: 82, minPoints: 980, minSamples: 380 },
         ],
         honors: {
             steelStreak: 16,
             riskyWarrior: 15,
             thousandService: 800,
+            l2Mastery: 120,
+            disciplineGuardMinScore: 90,
+            disciplineGuardMaxInvalid: 2,
+            disciplineGuardMinSamples: 220,
             riskyFailRatioThreshold: 0.65,
         },
         scoring: {
@@ -138,12 +150,18 @@ const policyProfiles = {
             { rank: '列兵', minHours: 8, minPoints: 45, minSamples: 16 },
             { rank: '士官', minHours: 18, minPoints: 130, minSamples: 50 },
             { rank: '尉官', minHours: 36, minPoints: 320, minSamples: 120 },
-            { rank: '王牌', minHours: 60, minPoints: 640, minSamples: 220 },
+            { rank: '校官', minHours: 42, minPoints: 420, minSamples: 150 },
+            { rank: '将官', minHours: 52, minPoints: 580, minSamples: 210 },
+            { rank: '王牌', minHours: 72, minPoints: 760, minSamples: 280 },
         ],
         honors: {
             steelStreak: 8,
             riskyWarrior: 8,
             thousandService: 300,
+            l2Mastery: 70,
+            disciplineGuardMinScore: 88,
+            disciplineGuardMaxInvalid: 2,
+            disciplineGuardMinSamples: 120,
             riskyFailRatioThreshold: 0.65,
         },
         scoring: {

--- a/apps/proxy-pool-service/src/config.test.js
+++ b/apps/proxy-pool-service/src/config.test.js
@@ -78,7 +78,7 @@ test('config should expose required default values', { concurrency: false }, () 
 test('config ranks should be ordered and complete', { concurrency: false }, () => {
     const config = loadConfigWithEnv();
     const ranks = config.policy.ranks.map((item) => item.rank);
-    assert.deepEqual(ranks, ['新兵', '列兵', '士官', '尉官', '王牌']);
+    assert.deepEqual(ranks, ['新兵', '列兵', '士官', '尉官', '校官', '将官', '王牌']);
     assert.equal(config.policy.promotionProtectHours, 6);
     assert.equal(config.policy.valueModel.combatPointCap, 1200);
     assert.equal(config.policy.valueModel.lifecycleScoreMap.retired, 8);

--- a/apps/proxy-pool-service/src/constants.js
+++ b/apps/proxy-pool-service/src/constants.js
@@ -1,4 +1,4 @@
-﻿const RANKS = ['新兵', '列兵', '士官', '尉官', '王牌'];
+const RANKS = ['新兵', '列兵', '士官', '尉官', '校官', '将官', '王牌'];
 const LIFECYCLE = ['candidate', 'active', 'reserve', 'retired'];
 
 const RETIREMENT_TYPES = {
@@ -12,6 +12,8 @@ const HONOR_TYPES = {
     STEEL_STREAK: '钢铁连胜',
     RISKY_WARRIOR: '逆风勇士',
     THOUSAND_SERVICE: '千次服役',
+    L2_MASTERY: '攻坚大师',
+    DISCIPLINE_GUARD: '铁纪标兵',
 };
 
 const EVENT_LEVEL = {

--- a/apps/proxy-pool-service/src/constants.test.js
+++ b/apps/proxy-pool-service/src/constants.test.js
@@ -3,9 +3,10 @@ const assert = require('node:assert/strict');
 const constants = require('./constants');
 
 test('constants should include lifecycle and ranks', () => {
-    assert.deepEqual(constants.RANKS, ['新兵', '列兵', '士官', '尉官', '王牌']);
+    assert.deepEqual(constants.RANKS, ['新兵', '列兵', '士官', '尉官', '校官', '将官', '王牌']);
     assert.deepEqual(constants.LIFECYCLE, ['candidate', 'active', 'reserve', 'retired']);
     assert.equal(constants.RETIREMENT_TYPES.HONOR, '荣誉退伍');
     assert.equal(constants.HONOR_TYPES.STEEL_STREAK, '钢铁连胜');
+    assert.equal(constants.HONOR_TYPES.L2_MASTERY, '攻坚大师');
     assert.equal(constants.EVENT_LEVEL.ERROR, 'error');
 });

--- a/apps/proxy-pool-service/src/rank.js
+++ b/apps/proxy-pool-service/src/rank.js
@@ -20,7 +20,11 @@ function safeParseJson(raw, fallback) {
 }
 
 // 0083_rankIndex_军衔逻辑
-function rankIndex(rank) {
+function rankIndex(rank, rankPolicies = []) {
+    if (Array.isArray(rankPolicies) && rankPolicies.length > 0) {
+        const idx = rankPolicies.findIndex((item) => item && item.rank === rank);
+        if (idx >= 0) return idx;
+    }
     return RANKS.indexOf(rank);
 }
 
@@ -211,11 +215,17 @@ function evaluateCombat({ proxy, outcome, latencyMs, nowIso, config, stage = 'l1
     let nextConsecutiveSuccess = proxy.consecutive_success || 0;
     let nextConsecutiveFail = proxy.consecutive_fail || 0;
     let nextRiskySuccess = proxy.risky_success_count || 0;
+    let nextBattleSuccess = proxy.battle_success_count || 0;
+    let nextBattleFail = proxy.battle_fail_count || 0;
+    const isBattleStage = stage === 'l1' || stage === 'l2';
 
     if (outcome === 'success') {
         nextSuccess += 1;
         nextConsecutiveSuccess += 1;
         nextConsecutiveFail = 0;
+        if (isBattleStage) {
+            nextBattleSuccess += 1;
+        }
         const riskyFailRatioThreshold = Number(selected.honors?.riskyFailRatioThreshold ?? 0.65);
         if (ratios.regular.failRatio >= riskyFailRatioThreshold) {
             nextRiskySuccess += 1;
@@ -223,6 +233,9 @@ function evaluateCombat({ proxy, outcome, latencyMs, nowIso, config, stage = 'l1
     } else {
         nextConsecutiveSuccess = 0;
         nextConsecutiveFail += 1;
+        if (isBattleStage) {
+            nextBattleFail += 1;
+        }
         if (outcome === 'blocked') {
             nextBlock += 1;
         } else if (outcome === 'timeout') {
@@ -271,7 +284,7 @@ function evaluateCombat({ proxy, outcome, latencyMs, nowIso, config, stage = 'l1
     let demoted = false;
     let retiredType = proxy.retired_type || null;
 
-    const currentRankIdx = rankIndex(nextRank);
+    const currentRankIdx = rankIndex(nextRank, selected.ranks);
     if (currentRankIdx >= 0 && currentRankIdx < selected.ranks.length - 1) {
         const nextRankPolicy = selected.ranks[currentRankIdx + 1];
         if (
@@ -315,7 +328,7 @@ function evaluateCombat({ proxy, outcome, latencyMs, nowIso, config, stage = 'l1
             || nextHealth < Number(demotion.healthThreshold ?? 40)
         );
 
-    const currentRankForDemotion = rankIndex(nextRank);
+    const currentRankForDemotion = rankIndex(nextRank, selected.ranks);
     if (currentRankForDemotion > 0 && currentRankForDemotion < selected.ranks.length) {
         if (severeDemotion || (!inProtectWindow && regularDemotion)) {
             nextRank = selected.ranks[currentRankForDemotion - 1].rank;
@@ -386,7 +399,7 @@ function evaluateCombat({ proxy, outcome, latencyMs, nowIso, config, stage = 'l1
         } else if (
             nextServiceHours >= Number(retirement.honorMinServiceHours || 720)
             && nextSuccess >= Number(retirement.honorMinSuccess || 800)
-            && ['尉官', '王牌'].includes(nextRank)
+            && ['尉官', '校官', '将官', '王牌'].includes(nextRank)
             && nextHealth >= 80
         ) {
             applyReserveGuard(RETIREMENT_TYPES.HONOR);
@@ -433,6 +446,19 @@ function evaluateCombat({ proxy, outcome, latencyMs, nowIso, config, stage = 'l1
         honorHistory.push(HONOR_TYPES.THOUSAND_SERVICE);
         awards.push({ type: HONOR_TYPES.THOUSAND_SERVICE, reason: '累计服役实战达到千次' });
     }
+    if (nextBattleSuccess >= Number(selected.honors.l2Mastery || 999999) && !hasHonor(HONOR_TYPES.L2_MASTERY)) {
+        honorHistory.push(HONOR_TYPES.L2_MASTERY);
+        awards.push({ type: HONOR_TYPES.L2_MASTERY, reason: 'L2 攻坚成功次数达标' });
+    }
+    if (
+        nextDiscipline >= Number(selected.honors.disciplineGuardMinScore || 999999)
+        && nextInvalid <= Number(selected.honors.disciplineGuardMaxInvalid ?? -1)
+        && nextTotalSamples >= Number(selected.honors.disciplineGuardMinSamples || 999999)
+        && !hasHonor(HONOR_TYPES.DISCIPLINE_GUARD)
+    ) {
+        honorHistory.push(HONOR_TYPES.DISCIPLINE_GUARD);
+        awards.push({ type: HONOR_TYPES.DISCIPLINE_GUARD, reason: '纪律稳定且低误报，达到铁纪标兵标准' });
+    }
 
     for (const award of awards) {
         events.push({
@@ -461,6 +487,17 @@ function evaluateCombat({ proxy, outcome, latencyMs, nowIso, config, stage = 'l1
     if (honorHistory.includes(HONOR_TYPES.THOUSAND_SERVICE)) {
         activeHonors.push(HONOR_TYPES.THOUSAND_SERVICE);
     }
+    if (honorHistory.includes(HONOR_TYPES.L2_MASTERY) && nextBattleSuccess >= Number(selected.honors.l2Mastery || 999999)) {
+        activeHonors.push(HONOR_TYPES.L2_MASTERY);
+    }
+    if (
+        honorHistory.includes(HONOR_TYPES.DISCIPLINE_GUARD)
+        && nextDiscipline >= Number(selected.honors.disciplineGuardMinScore || 999999)
+        && nextInvalid <= Number(selected.honors.disciplineGuardMaxInvalid ?? -1)
+        && nextTotalSamples >= Number(selected.honors.disciplineGuardMinSamples || 999999)
+    ) {
+        activeHonors.push(HONOR_TYPES.DISCIPLINE_GUARD);
+    }
 
     updates.service_hours = Number(nextServiceHours.toFixed(3));
     updates.rank_service_hours = updates.rank_service_hours ?? Number(nextRankServiceHours.toFixed(3));
@@ -476,6 +513,8 @@ function evaluateCombat({ proxy, outcome, latencyMs, nowIso, config, stage = 'l1
     updates.consecutive_success = nextConsecutiveSuccess;
     updates.consecutive_fail = nextConsecutiveFail;
     updates.risky_success_count = nextRiskySuccess;
+    updates.battle_success_count = nextBattleSuccess;
+    updates.battle_fail_count = nextBattleFail;
     updates.lifecycle = nextLifecycle;
     updates.rank = nextRank;
     updates.retired_type = retiredType;

--- a/apps/proxy-pool-service/src/rank.test.js
+++ b/apps/proxy-pool-service/src/rank.test.js
@@ -395,6 +395,29 @@ test('honor retirement should trigger when contribution is high', () => {
     assert.equal(result.updates.retired_type, '荣誉退伍');
 });
 
+test('honor retirement should also allow school-rank officers', () => {
+    const cfg = baseConfig();
+    const proxy = {
+        ...baseProxy(),
+        lifecycle: 'active',
+        rank: '校官',
+        service_hours: 760,
+        success_count: 830,
+        health_score: 90,
+        total_samples: 860,
+    };
+
+    const result = evaluateCombat({
+        proxy,
+        outcome: 'success',
+        latencyMs: 900,
+        nowIso: new Date().toISOString(),
+        config: cfg,
+    });
+
+    assert.equal(result.updates.retired_type, '荣誉退伍');
+});
+
 test('steel streak honor should be awarded', () => {
     const cfg = baseConfig();
     const proxy = {
@@ -451,6 +474,45 @@ test('risky warrior and thousand service honors should be awarded and active', (
     assert.equal(awardTypes.includes('逆风勇士'), true);
     assert.equal(awardTypes.includes('千次服役'), true);
     assert.equal(JSON.parse(result.updates.honor_active_json).includes('逆风勇士'), true);
+});
+
+test('l2 mastery and discipline guard honors should be awarded and active', () => {
+    const cfg = baseConfig();
+    cfg.policy.honors.l2Mastery = 2;
+    cfg.policy.honors.disciplineGuardMinScore = 95;
+    cfg.policy.honors.disciplineGuardMaxInvalid = 0;
+    cfg.policy.honors.disciplineGuardMinSamples = 6;
+
+    const now = new Date().toISOString();
+    const proxy = {
+        ...baseProxy(),
+        lifecycle: 'active',
+        rank: '校官',
+        total_samples: 5,
+        success_count: 5,
+        discipline_score: 100,
+        invalid_feedback_count: 0,
+        battle_success_count: 1,
+        battle_fail_count: 0,
+        honor_history_json: JSON.stringify([]),
+    };
+
+    const result = evaluateCombat({
+        proxy,
+        outcome: 'success',
+        latencyMs: 1100,
+        nowIso: now,
+        stage: 'l2',
+        config: cfg,
+    });
+
+    const awardTypes = result.awards.map((a) => a.type);
+    const activeHonors = JSON.parse(result.updates.honor_active_json);
+    assert.equal(result.updates.battle_success_count, 2);
+    assert.equal(awardTypes.includes('攻坚大师'), true);
+    assert.equal(awardTypes.includes('铁纪标兵'), true);
+    assert.equal(activeHonors.includes('攻坚大师'), true);
+    assert.equal(activeHonors.includes('铁纪标兵'), true);
 });
 
 test('combat events should include v1.1 details version', () => {


### PR DESCRIPTION
## Summary\n- expand rank ladder to 新兵 -> 列兵 -> 士官 -> 尉官 -> 校官 -> 将官 -> 王牌\n- add honor tracks: 攻坚大师 (L2_MASTERY) and 铁纪标兵 (DISCIPLINE_GUARD)\n- add profile thresholds for legacy/production/soak\n- align combat evaluation and active-honor maintenance rules\n- extend honor-retirement rank whitelist to include 校官 and 将官\n\n## Scope\n- pps/proxy-pool-service/src/constants.js\n- pps/proxy-pool-service/src/config.js\n- pps/proxy-pool-service/src/rank.js\n- tests updated accordingly (config/constants/rank)\n\n## Verification\n- 
pm run test:proxyhub:unit passed\n- 
pm run test:proxyhub:coverage passed\n  - Statements: 100%\n  - Lines: 100%\n  - Functions: 100%\n  - Branches: 98.23% (>= 98%)\n\nCloses #45