### PR TITLE
fix(proxyhub): 对应#47 修复军衔分布排序

### DIFF
--- a/apps/proxy-pool-service/src/db.js
+++ b/apps/proxy-pool-service/src/db.js
@@ -1108,8 +1108,10 @@ class ProxyHubDb {
                 WHEN '列兵' THEN 2
                 WHEN '士官' THEN 3
                 WHEN '尉官' THEN 4
-                WHEN '王牌' THEN 5
-                ELSE 6 END
+                WHEN '校官' THEN 5
+                WHEN '将官' THEN 6
+                WHEN '王牌' THEN 7
+                ELSE 8 END
         `).all();
     }
 

--- a/apps/proxy-pool-service/src/db.test.js
+++ b/apps/proxy-pool-service/src/db.test.js
@@ -273,6 +273,43 @@ test('query list APIs should support filters and distributions', () => {
     cleanup(h);
 });
 
+test('getRankBoard should keep 校官 and 将官 in canonical order', () => {
+    const h = createDb();
+    const now = new Date().toISOString();
+    const rankOrder = ['新兵', '列兵', '士官', '尉官', '校官', '将官', '王牌'];
+
+    h.db.upsertSourceBatch(
+        rankOrder.map((_, index) => ({
+            ip: `15.15.15.${index + 1}`,
+            port: 80,
+            protocol: 'http',
+        })),
+        (() => {
+            let i = 0;
+            return () => `军衔序-${++i}`;
+        })(),
+        'src-rank-board',
+        'batch-rank-board',
+        now,
+    );
+
+    const proxies = h.db.getProxyList({ limit: 20 });
+    for (let i = 0; i < rankOrder.length; i += 1) {
+        h.db.updateProxyById(proxies[i].id, {
+            rank: rankOrder[i],
+            updated_at: new Date(Date.parse(now) + i * 1000).toISOString(),
+        });
+    }
+
+    const board = h.db.getRankBoard();
+    const filtered = board
+        .map((item) => item.rank)
+        .filter((rank) => rankOrder.includes(rank));
+    assert.deepEqual(filtered, rankOrder);
+
+    cleanup(h);
+});
+
 test('value board API should sort by value and parse breakdown and honor fields', () => {
     const h = createDb();
     const now = new Date().toISOString();


### PR DESCRIPTION
## Summary
- 对应 #47：修复 `getRankBoard()` 的军衔排序 CASE，将 `校官/将官` 纳入标准序列。
- 现在返回顺序为：`新兵 -> 列兵 -> 士官 -> 尉官 -> 校官 -> 将官 -> 王牌`。
- 新增回归测试 `getRankBoard should keep 校官 and 将官 in canonical order`，锁定排序行为。

## Verification
- `npm.cmd run test:proxyhub:unit` ✅
- `npm.cmd run test:proxyhub:coverage` ✅
- Coverage gate 通过：lines 100 / statements 100 / functions 100 / branches 98.23

Closes #47