### PR TITLE
feat(proxyhub): switch default source to TheSpeedX 3-feed bundle + profile DB

### DIFF
--- a/apps/proxy-pool-service/src/config.js
+++ b/apps/proxy-pool-service/src/config.js
@@ -228,6 +228,79 @@ const resolvedLifecycleQuota = hasLifecycleQuotaEnv
     ? lifecycleQuotaFromEnv
     : (hasCandidateQuotaEnv ? undefined : defaultLifecycleQuota);
 
+const sourceProfiles = {
+    speedx_bundle: {
+        name: 'TheSpeedX/PROXY-List',
+        enabled: true,
+        dbPath: 'apps/proxy-pool-service/data/proxyhub-speedx-bundle.db',
+        feeds: [
+            {
+                name: 'TheSpeedX/http',
+                url: 'https://raw.githubusercontent.com/TheSpeedX/PROXY-List/master/http.txt',
+                enabled: true,
+                defaultProtocol: 'http',
+                sourceFormat: 'line',
+            },
+            {
+                name: 'TheSpeedX/socks4',
+                url: 'https://raw.githubusercontent.com/TheSpeedX/PROXY-List/master/socks4.txt',
+                enabled: true,
+                defaultProtocol: 'socks4',
+                sourceFormat: 'line',
+            },
+            {
+                name: 'TheSpeedX/socks5',
+                url: 'https://raw.githubusercontent.com/TheSpeedX/PROXY-List/master/socks5.txt',
+                enabled: true,
+                defaultProtocol: 'socks5',
+                sourceFormat: 'line',
+            },
+        ],
+    },
+    monosans_archive: {
+        name: 'monosans/proxy-list',
+        enabled: false,
+        dbPath: 'apps/proxy-pool-service/data/proxyhub-v1.db',
+        feeds: [
+            {
+                name: 'monosans/proxy-list',
+                url: 'https://raw.githubusercontent.com/monosans/proxy-list/main/proxies.json',
+                enabled: true,
+                defaultProtocol: 'http',
+                sourceFormat: 'json',
+            },
+        ],
+    },
+};
+
+const sourceProfileRaw = String(process.env.PROXY_HUB_SOURCE_PROFILE || '').trim().toLowerCase();
+const activeSourceProfile = Object.prototype.hasOwnProperty.call(sourceProfiles, sourceProfileRaw)
+    ? sourceProfileRaw
+    : 'speedx_bundle';
+const selectedSourceProfile = deepClone(sourceProfiles[activeSourceProfile]);
+
+const hasLegacySourceOverride = hasOwnEnv('PROXY_HUB_SOURCE_NAME')
+    || hasOwnEnv('PROXY_HUB_SOURCE_URL')
+    || hasOwnEnv('PROXY_HUB_SOURCE_ENABLED')
+    || hasOwnEnv('PROXY_HUB_SOURCE_DEFAULT_PROTOCOL')
+    || hasOwnEnv('PROXY_HUB_SOURCE_FORMAT');
+
+const legacySingleSourceFeed = {
+    name: process.env.PROXY_HUB_SOURCE_NAME || 'monosans/proxy-list',
+    url: process.env.PROXY_HUB_SOURCE_URL || 'https://raw.githubusercontent.com/monosans/proxy-list/main/proxies.json',
+    enabled: toBool(process.env.PROXY_HUB_SOURCE_ENABLED, true),
+    defaultProtocol: String(process.env.PROXY_HUB_SOURCE_DEFAULT_PROTOCOL || 'http').toLowerCase(),
+    sourceFormat: String(process.env.PROXY_HUB_SOURCE_FORMAT || 'json').toLowerCase(),
+};
+
+let activeSourceFeeds = deepClone(selectedSourceProfile.feeds);
+if (hasLegacySourceOverride) {
+    activeSourceFeeds = [legacySingleSourceFeed];
+}
+
+const defaultStorageDbPath = selectedSourceProfile.dbPath;
+const resolvedStorageDbPath = process.env.PROXY_HUB_DB_PATH || defaultStorageDbPath;
+
 module.exports = {
     service: {
         name: 'ProxyHub',
@@ -237,7 +310,7 @@ module.exports = {
         logRetention: 2000,
     },
     storage: {
-        dbPath: process.env.PROXY_HUB_DB_PATH || 'apps/proxy-pool-service/data/proxyhub-v1.db',
+        dbPath: resolvedStorageDbPath,
         snapshotRetentionDays: 7,
     },
     threadPool: {
@@ -338,16 +411,14 @@ module.exports = {
         },
     },
     source: {
-        monosans: {
-            name: process.env.PROXY_HUB_SOURCE_NAME || 'monosans/proxy-list',
-            url: process.env.PROXY_HUB_SOURCE_URL || 'https://raw.githubusercontent.com/monosans/proxy-list/main/proxies.json',
-            enabled: toBool(process.env.PROXY_HUB_SOURCE_ENABLED, true),
-            defaultProtocol: String(process.env.PROXY_HUB_SOURCE_DEFAULT_PROTOCOL || 'http').toLowerCase(),
-            sourceFormat: String(process.env.PROXY_HUB_SOURCE_FORMAT || 'json').toLowerCase(),
-        },
+        activeProfile: activeSourceProfile,
+        profiles: deepClone(sourceProfiles),
+        activeFeeds: deepClone(activeSourceFeeds),
+        legacySingleOverride: hasLegacySourceOverride,
+        monosans: deepClone(sourceProfiles.monosans_archive.feeds[0]),
     },
     validation: {
-        allowedProtocols: ['http', 'https', 'socks5'],
+        allowedProtocols: ['http', 'https', 'socks4', 'socks5'],
         maxTimeoutMs: 2_500,
     },
     policyProfiles: deepClone(policyProfiles),

--- a/apps/proxy-pool-service/src/config.test.js
+++ b/apps/proxy-pool-service/src/config.test.js
@@ -13,6 +13,7 @@ function loadConfigWithEnv(overrides = {}) {
         'PROXY_HUB_ROLLOUT_COOLDOWN_HOURS',
         'PROXY_HUB_ROLLOUT_MIN_L2_SAMPLES',
         'PROXY_HUB_ROLLOUT_LEASE_TTL_MS',
+        'PROXY_HUB_POLICY_PROFILE',
         'PROXY_HUB_CANDIDATE_MAX',
         'PROXY_HUB_CANDIDATE_GATE_OVERRIDE',
         'PROXY_HUB_CANDIDATE_SWEEP_MS',
@@ -31,6 +32,8 @@ function loadConfigWithEnv(overrides = {}) {
         'PROXY_HUB_SOURCE_ENABLED',
         'PROXY_HUB_SOURCE_DEFAULT_PROTOCOL',
         'PROXY_HUB_SOURCE_FORMAT',
+        'PROXY_HUB_SOURCE_PROFILE',
+        'PROXY_HUB_DB_PATH',
         ...Object.keys(overrides),
     ]);
     const originals = {};
@@ -65,8 +68,14 @@ test('config should expose required default values', { concurrency: false }, () 
     assert.equal(config.service.timezone, 'Asia/Shanghai');
     assert.equal(config.threadPool.workers > 0, true);
     assert.equal(Array.isArray(config.validation.allowedProtocols), true);
-    assert.equal(config.source.monosans.enabled, true);
-    assert.equal(config.source.monosans.url.includes('proxies.json'), true);
+    assert.equal(config.source.activeProfile, 'speedx_bundle');
+    assert.equal(config.source.legacySingleOverride, false);
+    assert.equal(Array.isArray(config.source.activeFeeds), true);
+    assert.equal(config.source.activeFeeds.length, 3);
+    assert.equal(config.source.activeFeeds[0].url.includes('/http.txt'), true);
+    assert.equal(config.source.profiles.monosans_archive.enabled, false);
+    assert.equal(config.storage.dbPath.includes('proxyhub-speedx-bundle.db'), true);
+    assert.equal(config.validation.allowedProtocols.includes('socks4'), true);
     assert.equal(config.battle.enabled, true);
     assert.equal(config.battle.l1SyncMs, 300000);
     assert.equal(config.battle.l2SyncMs, 1800000);
@@ -106,11 +115,33 @@ test('config should support source override for line-based lists', { concurrency
         PROXY_HUB_SOURCE_FORMAT: 'line',
     });
 
-    assert.equal(config.source.monosans.name, 'TheSpeedX/PROXY-List');
-    assert.equal(config.source.monosans.url.includes('/socks5.txt'), true);
-    assert.equal(config.source.monosans.enabled, true);
-    assert.equal(config.source.monosans.defaultProtocol, 'socks5');
-    assert.equal(config.source.monosans.sourceFormat, 'line');
+    assert.equal(config.source.legacySingleOverride, true);
+    assert.equal(config.source.activeFeeds.length, 1);
+    assert.equal(config.source.activeFeeds[0].name, 'TheSpeedX/PROXY-List');
+    assert.equal(config.source.activeFeeds[0].url.includes('/socks5.txt'), true);
+    assert.equal(config.source.activeFeeds[0].enabled, true);
+    assert.equal(config.source.activeFeeds[0].defaultProtocol, 'socks5');
+    assert.equal(config.source.activeFeeds[0].sourceFormat, 'line');
+});
+
+test('config should switch db and feeds by source profile when env profile changes', { concurrency: false }, () => {
+    const config = loadConfigWithEnv({
+        PROXY_HUB_SOURCE_PROFILE: 'monosans_archive',
+    });
+
+    assert.equal(config.source.activeProfile, 'monosans_archive');
+    assert.equal(config.source.activeFeeds.length, 1);
+    assert.equal(config.source.activeFeeds[0].url.includes('proxies.json'), true);
+    assert.equal(config.storage.dbPath.includes('proxyhub-v1.db'), true);
+});
+
+test('config should prioritize explicit PROXY_HUB_DB_PATH over profile db mapping', { concurrency: false }, () => {
+    const config = loadConfigWithEnv({
+        PROXY_HUB_SOURCE_PROFILE: 'speedx_bundle',
+        PROXY_HUB_DB_PATH: 'apps/proxy-pool-service/data/manual-override.db',
+    });
+
+    assert.equal(config.storage.dbPath, 'apps/proxy-pool-service/data/manual-override.db');
 });
 
 test('config should parse rollout feature bool env values', { concurrency: false }, () => {

--- a/apps/proxy-pool-service/src/engine.js
+++ b/apps/proxy-pool-service/src/engine.js
@@ -165,6 +165,36 @@ function resolveFailureBackoff({
     };
 }
 
+// 0266_resolveSourceFeeds_解析抓源配置逻辑
+function resolveSourceFeeds(config = {}) {
+    const source = config.source || {};
+
+    if (Array.isArray(source.activeFeeds) && source.activeFeeds.length > 0) {
+        return source.activeFeeds
+            .filter((feed) => feed && typeof feed === 'object' && feed.enabled !== false)
+            .map((feed) => ({
+                name: String(feed.name || 'unknown-source'),
+                url: String(feed.url || ''),
+                enabled: feed.enabled !== false,
+                sourceFormat: String(feed.sourceFormat || 'auto').toLowerCase(),
+                defaultProtocol: String(feed.defaultProtocol || 'http').toLowerCase(),
+            }))
+            .filter((feed) => feed.url.length > 0);
+    }
+
+    if (source.monosans && source.monosans.enabled !== false && source.monosans.url) {
+        return [{
+            name: String(source.monosans.name || 'monosans/proxy-list'),
+            url: String(source.monosans.url),
+            enabled: true,
+            sourceFormat: String(source.monosans.sourceFormat || 'auto').toLowerCase(),
+            defaultProtocol: String(source.monosans.defaultProtocol || 'http').toLowerCase(),
+        }];
+    }
+
+    return [];
+}
+
 class ProxyHubEngine extends EventEmitter {
     // 0027_constructor_初始化实例逻辑
     constructor({ config, db, workerPool, logger, now }) {
@@ -291,96 +321,121 @@ class ProxyHubEngine extends EventEmitter {
             return;
         }
 
-        const sourceConfig = this.config.source.monosans;
-        if (!sourceConfig?.enabled) {
+        const sourceFeeds = resolveSourceFeeds(this.config);
+        if (sourceFeeds.length === 0) {
             return;
         }
 
         this.isSourceCycleRunning = true;
         const startedAt = Date.now();
-        const sourceName = sourceConfig.name;
-
-        this.logger.write({
-            event: '开始抓源',
-            stage: '抓源',
-            ipSource: sourceName,
-            result: '开始',
-            action: '拉取代理来源',
-        });
+        const summary = {
+            feeds: sourceFeeds.length,
+            fetched: 0,
+            normalized: 0,
+            inserted: 0,
+            touched: 0,
+            skipped: 0,
+            failed: 0,
+        };
 
         try {
-            const fetchResult = await this.workerPool.runTask('fetch-source', {
-                url: sourceConfig.url,
-                timeoutMs: 20_000,
-                allowedProtocols: this.config.validation.allowedProtocols,
-                defaultProtocol: sourceConfig.defaultProtocol,
-                sourceFormat: sourceConfig.sourceFormat,
-            });
-
-            const batchId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-            const nowIso = this.now().toISOString();
-            const candidateCount = Number(this.db.getLifecycleCount?.('candidate') || 0);
-            const gateState = buildCandidateGateState(this.config, candidateCount);
-            const upsertStats = this.db.upsertSourceBatch(
-                fetchResult.proxies,
-                () => this.createRecruitName(),
-                sourceName,
-                batchId,
-                nowIso,
-                {
-                    allowInsert: !gateState.gateActive,
-                },
-            );
-
-            this.logger.write({
-                event: '抓源成功',
-                stage: '抓源',
-                ipSource: sourceName,
-                result: `总 ${fetchResult.normalized}，新增 ${upsertStats.inserted}，更新 ${upsertStats.touched}，跳过 ${upsertStats.skipped || 0}`,
-                durationMs: Date.now() - startedAt,
-                action: gateState.gateActive ? 'candidate闸门生效，仅更新存量代理' : '进入校验队列',
-            });
-
-            if (gateState.gateActive || (gateState.gatedByThreshold && gateState.gateOverride)) {
-                const gateMessage = gateState.gateActive
-                    ? `candidate 闸门生效：当前 ${gateState.candidateCount}，上限 ${gateState.max}`
-                    : `candidate 闸门已手工 override：当前 ${gateState.candidateCount}，上限 ${gateState.max}`;
-                this.db.insertProxyEvent({
-                    timestamp: nowIso,
-                    proxy_id: null,
-                    display_name: null,
-                    event_type: 'candidate_gate',
-                    level: EVENT_LEVEL.INFO,
-                    message: gateMessage,
-                    details: {
-                        candidateCount: gateState.candidateCount,
-                        candidateMax: gateState.max,
-                        gateActive: gateState.gateActive,
-                        gateOverride: gateState.gateOverride,
-                        inserted: upsertStats.inserted,
-                        touched: upsertStats.touched,
-                        skipped: upsertStats.skipped || 0,
-                    },
+            for (const sourceConfig of sourceFeeds) {
+                const sourceName = sourceConfig.name;
+                this.logger.write({
+                    event: '开始抓源',
+                    stage: '抓源',
+                    ipSource: sourceName,
+                    result: '开始',
+                    action: '拉取代理来源',
                 });
+
+                try {
+                    const fetchResult = await this.workerPool.runTask('fetch-source', {
+                        url: sourceConfig.url,
+                        timeoutMs: 20_000,
+                        allowedProtocols: this.config.validation.allowedProtocols,
+                        defaultProtocol: sourceConfig.defaultProtocol,
+                        sourceFormat: sourceConfig.sourceFormat,
+                    });
+
+                    const batchId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+                    const nowIso = this.now().toISOString();
+                    const candidateCount = Number(this.db.getLifecycleCount?.('candidate') || 0);
+                    const gateState = buildCandidateGateState(this.config, candidateCount);
+                    const upsertStats = this.db.upsertSourceBatch(
+                        fetchResult.proxies,
+                        () => this.createRecruitName(),
+                        sourceName,
+                        batchId,
+                        nowIso,
+                        {
+                            allowInsert: !gateState.gateActive,
+                        },
+                    );
+
+                    summary.fetched += Number(fetchResult.fetched || 0);
+                    summary.normalized += Number(fetchResult.normalized || 0);
+                    summary.inserted += Number(upsertStats.inserted || 0);
+                    summary.touched += Number(upsertStats.touched || 0);
+                    summary.skipped += Number(upsertStats.skipped || 0);
+
+                    this.logger.write({
+                        event: '抓源成功',
+                        stage: '抓源',
+                        ipSource: sourceName,
+                        result: `总 ${fetchResult.normalized}，新增 ${upsertStats.inserted}，更新 ${upsertStats.touched}，跳过 ${upsertStats.skipped || 0}`,
+                        durationMs: Date.now() - startedAt,
+                        action: gateState.gateActive ? 'candidate闸门生效，仅更新存量代理' : '进入校验队列',
+                    });
+
+                    if (gateState.gateActive || (gateState.gatedByThreshold && gateState.gateOverride)) {
+                        const gateMessage = gateState.gateActive
+                            ? `candidate 闸门生效：当前 ${gateState.candidateCount}，上限 ${gateState.max}`
+                            : `candidate 闸门已手工 override：当前 ${gateState.candidateCount}，上限 ${gateState.max}`;
+                        this.db.insertProxyEvent({
+                            timestamp: nowIso,
+                            proxy_id: null,
+                            display_name: null,
+                            event_type: 'candidate_gate',
+                            level: EVENT_LEVEL.INFO,
+                            message: gateMessage,
+                            details: {
+                                sourceName,
+                                candidateCount: gateState.candidateCount,
+                                candidateMax: gateState.max,
+                                gateActive: gateState.gateActive,
+                                gateOverride: gateState.gateOverride,
+                                inserted: upsertStats.inserted,
+                                touched: upsertStats.touched,
+                                skipped: upsertStats.skipped || 0,
+                            },
+                        });
+                    }
+                } catch (error) {
+                    summary.failed += 1;
+                    this.logger.write({
+                        event: '抓源失败',
+                        stage: '抓源',
+                        ipSource: sourceName,
+                        result: '失败',
+                        reason: error?.message || 'unknown',
+                        durationMs: Date.now() - startedAt,
+                        action: '等待自动重试',
+                    });
+                }
             }
 
-            await this.runValidationCycle(sourceName);
+            if (summary.failed >= sourceFeeds.length) {
+                return;
+            }
+
+            await this.runValidationCycle(this.config.source?.activeProfile || 'source-bundle');
             this.logger.write({
                 event: '等待下一轮',
                 stage: '抓源',
-                ipSource: sourceName,
-                result: '本轮完成',
+                ipSource: this.config.source?.activeProfile || 'source-bundle',
+                result: `本轮完成：源 ${summary.feeds}，抓取 ${summary.fetched}，标准化 ${summary.normalized}，新增 ${summary.inserted}，更新 ${summary.touched}`,
                 action: '等待调度器下次触发',
-            });
-        } catch (error) {
-            this.logger.write({
-                event: '抓源失败',
-                stage: '抓源',
-                ipSource: sourceName,
-                result: '失败',
-                reason: error?.message || 'unknown',
-                durationMs: Date.now() - startedAt,
-                action: '等待自动重试',
             });
         } finally {
             this.isSourceCycleRunning = false;
@@ -1079,6 +1134,7 @@ module.exports = {
     buildCandidateGateState,
     readFailureBackoff,
     resolveFailureBackoff,
+    resolveSourceFeeds,
     ProxyHubEngine,
 };
 

--- a/apps/proxy-pool-service/src/engine.test.js
+++ b/apps/proxy-pool-service/src/engine.test.js
@@ -15,6 +15,7 @@ const {
     buildCandidateGateState,
     readFailureBackoff,
     resolveFailureBackoff,
+    resolveSourceFeeds,
     ProxyHubEngine,
 } = require('./engine');
 
@@ -60,7 +61,7 @@ function createConfig(dbPath) {
             multiplier: 2,
             maxMs: 3600000,
         },
-        validation: { allowedProtocols: ['http', 'https', 'socks5'], maxTimeoutMs: 1000 },
+        validation: { allowedProtocols: ['http', 'https', 'socks4', 'socks5'], maxTimeoutMs: 1000 },
         policy: {
             serviceHourScale: 3,
             promotionProtectHours: 6,
@@ -193,6 +194,37 @@ test('engine utility functions should cover helper branches', async () => {
         multiplier: 1.8,
         maxMs: 21600000,
     });
+    assert.deepEqual(resolveSourceFeeds(), []);
+    assert.deepEqual(resolveSourceFeeds({ source: {} }), []);
+    assert.equal(resolveSourceFeeds({
+        source: {
+            activeFeeds: [
+                { name: 'feed1', url: 'https://example.com/1', enabled: true, sourceFormat: 'line', defaultProtocol: 'socks5' },
+                { name: 'feed2', url: 'https://example.com/2', enabled: false },
+            ],
+        },
+    }).length, 1);
+    assert.equal(resolveSourceFeeds({
+        source: {
+            monosans: { name: 'legacy', url: 'https://example.com/legacy', enabled: true },
+        },
+    }).length, 1);
+    assert.equal(resolveSourceFeeds({
+        source: {
+            monosans: { url: 'https://example.com/legacy-default-name', enabled: true },
+        },
+    })[0].name, 'monosans/proxy-list');
+    const fallbackFeed = resolveSourceFeeds({
+        source: {
+            activeFeeds: [
+                { url: 'https://example.com/fallback-feed' },
+            ],
+        },
+    })[0];
+    assert.equal(fallbackFeed.name, 'unknown-source');
+    assert.equal(fallbackFeed.url, 'https://example.com/fallback-feed');
+    assert.equal(fallbackFeed.sourceFormat, 'auto');
+    assert.equal(fallbackFeed.defaultProtocol, 'http');
     const backoff = resolveFailureBackoff({
         config: {
             failureBackoff: {
@@ -438,6 +470,98 @@ test('runSourceCycle and processProxy should handle success path', async () => {
     assert.equal(logger.entries.some((e) => e.event === '抓源成功'), true);
     assert.equal(logger.entries.some((e) => e.event === '校验通过'), true);
     assert.equal(logger.entries.some((e) => e.stage === '评分(L0回退)' && e.result === '成功'), true);
+
+    cleanupDb(h);
+});
+
+test('runSourceCycle should fetch multiple active feeds and validate once', async () => {
+    const h = createDbHandle();
+    const logger = createLogger();
+    h.config.source = {
+        activeProfile: 'speedx_bundle',
+        activeFeeds: [
+            {
+                name: 'TheSpeedX/http',
+                url: 'https://example.com/http.txt',
+                enabled: true,
+                sourceFormat: 'line',
+                defaultProtocol: 'http',
+            },
+            {
+                name: 'TheSpeedX/socks4',
+                url: 'https://example.com/socks4.txt',
+                enabled: true,
+                sourceFormat: 'line',
+                defaultProtocol: 'socks4',
+            },
+            {
+                name: 'TheSpeedX/socks5',
+                url: 'https://example.com/socks5.txt',
+                enabled: true,
+                sourceFormat: 'line',
+                defaultProtocol: 'socks5',
+            },
+        ],
+    };
+
+    let fetchCalls = 0;
+    let validateCalls = 0;
+    const workerPool = {
+        async runTask(type, payload) {
+            if (type === 'fetch-source') {
+                fetchCalls += 1;
+                if (payload.defaultProtocol === 'http') {
+                    return {
+                        fetched: 1,
+                        normalized: 1,
+                        proxies: [{ ip: '10.9.0.1', port: 8080, protocol: 'http' }],
+                    };
+                }
+                if (payload.defaultProtocol === 'socks4') {
+                    return {
+                        fetched: 1,
+                        normalized: 1,
+                        proxies: [{ ip: '10.9.0.2', port: 1080, protocol: 'socks4' }],
+                    };
+                }
+                return {
+                    fetched: 1,
+                    normalized: 1,
+                    proxies: [{ ip: '10.9.0.3', port: 1080, protocol: 'socks5' }],
+                };
+            }
+            if (type === 'validate-proxy') {
+                validateCalls += 1;
+                return { ok: true, reason: 'connect_ok', latencyMs: 12 };
+            }
+            return { ok: true };
+        },
+        getStatus() {
+            return {
+                workersTotal: 2,
+                workersBusy: 0,
+                queueSize: 0,
+                runningTasks: 0,
+                completedTasks: 0,
+                failedTasks: 0,
+                restartedWorkers: 0,
+                workers: [],
+            };
+        },
+    };
+
+    const engine = new ProxyHubEngine({ config: h.config, db: h.db, workerPool, logger, now: () => new Date('2026-03-14T01:10:00.000Z') });
+    engine.started = true;
+
+    await engine.runSourceCycle();
+
+    const proxies = h.db.getProxyList({ limit: 20 });
+    assert.equal(fetchCalls, 3);
+    assert.equal(proxies.length, 3);
+    assert.equal(validateCalls, 3);
+    assert.equal(proxies.some((item) => item.protocol === 'socks4'), true);
+    assert.equal(logger.entries.some((entry) => entry.event === '抓源成功' && entry.ipSource === 'TheSpeedX/socks4'), true);
+    assert.equal(logger.entries.some((entry) => entry.event === '等待下一轮' && entry.ipSource === 'speedx_bundle'), true);
 
     cleanupDb(h);
 });
@@ -1286,12 +1410,19 @@ test('runBattle cycles should log outer-catch fallback reason when candidate lis
     const config = createConfig(path.join(os.tmpdir(), 'proxyhub-engine-battle-outer.db'));
     config.battle.enabled = true;
 
+    let throwMode = 'null';
     const db = {
         listProxiesForBattleL1() {
-            throw null;
+            if (throwMode === 'null') {
+                throw null;
+            }
+            throw new Error('battle-l1-list-fail');
         },
         listProxiesForBattleL2() {
-            throw null;
+            if (throwMode === 'null') {
+                throw null;
+            }
+            throw new Error('battle-l2-list-fail');
         },
     };
     const workerPool = {
@@ -1310,6 +1441,12 @@ test('runBattle cycles should log outer-catch fallback reason when candidate lis
 
     assert.equal(logger.entries.some((e) => e.event === '线程池告警' && e.stage === '战场测试L1' && e.reason === 'battle-l1-error'), true);
     assert.equal(logger.entries.some((e) => e.event === '线程池告警' && e.stage === '战场测试L2' && e.reason === 'battle-l2-error'), true);
+
+    throwMode = 'message';
+    await engine.runBattleL1Cycle();
+    await engine.runBattleL2Cycle();
+    assert.equal(logger.entries.some((e) => e.event === '线程池告警' && e.stage === '战场测试L1' && e.reason === 'battle-l1-list-fail'), true);
+    assert.equal(logger.entries.some((e) => e.event === '线程池告警' && e.stage === '战场测试L2' && e.reason === 'battle-l2-list-fail'), true);
 });
 
 test('runSourceCycle should audit manual override gate branch', async () => {
@@ -1361,9 +1498,14 @@ test('runSourceCycle should audit manual override gate branch', async () => {
 test('runCandidateSweepCycle should use fallback reason and counters when candidate fields are missing', async () => {
     const config = createConfig(path.join(os.tmpdir(), 'proxyhub-engine-sweep-fallback.db'));
     const logger = createLogger();
+    let pass = 0;
     const db = {
         listCandidatesForSweep() {
-            return [{ id: 1, display_name: '清库存-缺省-01' }];
+            pass += 1;
+            if (pass === 1) {
+                return [{ id: 1, display_name: '清库存-缺省-01' }];
+            }
+            return [{ id: 2, display_name: '清库存-超时-02', sweep_reason: 'stale_timeout' }];
         },
         updateProxyById() {},
         insertRetirement() {},
@@ -1386,7 +1528,9 @@ test('runCandidateSweepCycle should use fallback reason and counters when candid
     });
     engine.started = true;
     await engine.runCandidateSweepCycle();
+    await engine.runCandidateSweepCycle();
     assert.equal(logger.entries.some((entry) => entry.stage === 'candidate-sweeper' && String(entry.action).includes('stale_timeout=0')), true);
+    assert.equal(logger.entries.some((entry) => entry.stage === 'candidate-sweeper' && String(entry.action).includes('stale_candidate=0')), true);
 });
 
 test('runStateReviewCycle should cover change/no-change and error branches', async () => {

--- a/apps/proxy-pool-service/src/worker.js
+++ b/apps/proxy-pool-service/src/worker.js
@@ -125,7 +125,7 @@ async function fetchSourceTask(payload, deps = {}) {
 
     const sourceFormat = String(payload.sourceFormat || 'auto').toLowerCase();
     const defaultProtocol = String(payload.defaultProtocol || 'http').toLowerCase();
-    const allowedProtocols = payload.allowedProtocols || ['http', 'https', 'socks5'];
+    const allowedProtocols = payload.allowedProtocols || ['http', 'https', 'socks4', 'socks5'];
 
     let rawText = '';
     if (typeof res.text === 'function') {

--- a/apps/proxy-pool-service/src/worker.test.js
+++ b/apps/proxy-pool-service/src/worker.test.js
@@ -47,12 +47,14 @@ test('normalizeProxyPayload should deduplicate and filter invalid protocols', ()
         { ip: '1.1.1.2', port: 81 },
         { ip: '2.2.2.2', port: 0, protocol: 'http' },
         { ip: '', port: 8080, protocol: 'http' },
+        { ip: '3.3.3.3', port: 1080, protocol: 'socks4' },
         { ip: '3.3.3.3', port: 1080, protocol: 'socks5' },
-    ], ['http', 'https', 'socks5']);
+    ], ['http', 'https', 'socks4', 'socks5']);
 
-    assert.equal(normalized.length, 3);
+    assert.equal(normalized.length, 4);
     assert.equal(normalized.some((x) => x.protocol === 'http'), true);
     assert.equal(normalized.some((x) => x.protocol === 'https'), true);
+    assert.equal(normalized.some((x) => x.protocol === 'socks4'), true);
     assert.equal(normalized.some((x) => x.protocol === 'socks5'), true);
 });
 
@@ -111,6 +113,26 @@ test('fetchSourceTask should support line-based source format and protocol fallb
     assert.equal(result.normalized, 2);
     assert.equal(result.proxies.some((x) => x.ip === '66.42.59.155' && x.protocol === 'socks5'), true);
     assert.equal(result.proxies.some((x) => x.ip === '1.1.1.1' && x.protocol === 'socks5'), true);
+});
+
+test('fetchSourceTask should accept socks4 protocol when allowed', async () => {
+    const result = await fetchSourceTask({
+        url: 'https://example.com/socks4.txt',
+        allowedProtocols: ['socks4'],
+        sourceFormat: 'line',
+        defaultProtocol: 'socks4',
+    }, {
+        fetchImpl: async () => ({
+            ok: true,
+            status: 200,
+            async text() {
+                return '4.4.4.4:4145\n5.5.5.5:1080';
+            },
+        }),
+    });
+
+    assert.equal(result.normalized, 2);
+    assert.equal(result.proxies.every((item) => item.protocol === 'socks4'), true);
 });
 
 test('fetchSourceTask should fallback to line parsing in auto mode and reject invalid json mode', async () => {

--- a/apps/proxy-pool-service/tests/cli.integration.test.js
+++ b/apps/proxy-pool-service/tests/cli.integration.test.js
@@ -105,3 +105,40 @@ test('integration: soak CLI should finish with tiny duration', async () => {
 
     fs.rmSync(tmpDir, { recursive: true, force: true });
 });
+
+test('integration: server CLI should create speedx profile default db when DB_PATH is not set', async () => {
+    const port = 5094;
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'proxyhub-default-db-'));
+    const serverScript = path.resolve(process.cwd(), 'apps/proxy-pool-service/src/server.js');
+
+    const child = spawn(process.execPath, [serverScript], {
+        cwd: tmpDir,
+        env: {
+            ...process.env,
+            PROXY_HUB_PORT: String(port),
+            PROXY_HUB_SOURCE_ENABLED: 'false',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stderr = '';
+    child.stderr.on('data', (d) => {
+        stderr += String(d);
+    });
+
+    await waitFor(async () => {
+        const res = await fetch(`http://127.0.0.1:${port}/health`, { signal: AbortSignal.timeout(5000) });
+        return res.ok;
+    }, 20000, 300);
+
+    child.kill('SIGTERM');
+    await new Promise((resolve) => {
+        child.on('exit', () => resolve());
+    });
+
+    const expectedDb = path.join(tmpDir, 'apps/proxy-pool-service/data/proxyhub-speedx-bundle.db');
+    assert.equal(fs.existsSync(expectedDb), true);
+    assert.equal(stderr.includes('Error'), false);
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+});

--- a/apps/proxy-pool-service/tests/network.integration.test.js
+++ b/apps/proxy-pool-service/tests/network.integration.test.js
@@ -9,49 +9,61 @@ function sleep(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-test('integration: monosans source should be reachable with retry and snapshot on failure', async () => {
-    const url = config.source.monosans.url;
+test('integration: speedx feeds should be reachable with retry and snapshot on failure', async () => {
+    const urls = (config.source.profiles?.speedx_bundle?.feeds || []).map((feed) => feed.url);
     const maxRetries = 2;
     const snapshotsDir = path.resolve(process.cwd(), 'apps/proxy-pool-service/data/test-failures');
     fs.mkdirSync(snapshotsDir, { recursive: true });
 
-    let lastError = null;
-    for (let attempt = 1; attempt <= maxRetries + 1; attempt += 1) {
-        try {
-            const res = await fetch(url, {
-                signal: AbortSignal.timeout(20000),
-                headers: {
-                    'user-agent': 'ProxyHub-IntegrationTest/1.0',
-                    accept: 'application/json,text/plain,*/*',
-                },
-            });
+    assert.equal(urls.length, 3);
 
-            if (!res.ok) {
-                throw new Error(`http-${res.status}`);
-            }
+    for (const url of urls) {
+        let lastError = null;
+        for (let attempt = 1; attempt <= maxRetries + 1; attempt += 1) {
+            try {
+                const res = await fetch(url, {
+                    signal: AbortSignal.timeout(20000),
+                    headers: {
+                        'user-agent': 'ProxyHub-IntegrationTest/1.0',
+                        accept: 'application/json,text/plain,*/*',
+                    },
+                });
 
-            const body = await res.json();
-            assert.equal(Array.isArray(body), true);
-            assert.equal(body.length > 0, true);
-            return;
-        } catch (error) {
-            lastError = error;
-            if (attempt <= maxRetries) {
-                await sleep(500 * attempt);
+                if (!res.ok) {
+                    throw new Error(`http-${res.status}`);
+                }
+
+                const body = await res.text();
+                const lines = String(body)
+                    .split(/\r?\n/)
+                    .map((line) => line.trim())
+                    .filter((line) => line.length > 0 && !line.startsWith('#') && !line.startsWith('//'));
+                assert.equal(lines.length > 0, true);
+                lastError = null;
+                break;
+            } catch (error) {
+                lastError = error;
+                if (attempt <= maxRetries) {
+                    await sleep(500 * attempt);
+                }
             }
         }
+
+        if (!lastError) {
+            continue;
+        }
+
+        const snapshotFile = path.join(
+            snapshotsDir,
+            `speedx-failure-${new Date().toISOString().replace(/[:.]/g, '-')}.json`,
+        );
+        fs.writeFileSync(snapshotFile, JSON.stringify({
+            timestamp: new Date().toISOString(),
+            url,
+            retries: maxRetries,
+            error: lastError?.message || String(lastError),
+        }, null, 2), 'utf8');
+
+        assert.fail(`speedx source unavailable after retries. snapshot=${snapshotFile}`);
     }
-
-    const snapshotFile = path.join(
-        snapshotsDir,
-        `monosans-failure-${new Date().toISOString().replace(/[:.]/g, '-')}.json`,
-    );
-    fs.writeFileSync(snapshotFile, JSON.stringify({
-        timestamp: new Date().toISOString(),
-        url,
-        retries: maxRetries,
-        error: lastError?.message || String(lastError),
-    }, null, 2), 'utf8');
-
-    assert.fail(`monosans source unavailable after retries. snapshot=${snapshotFile}`);
 });

--- a/docs/22_模块18_源档案与独立DB切换说明.md
+++ b/docs/22_模块18_源档案与独立DB切换说明.md
@@ -1,0 +1,36 @@
+﻿# 模块18：源档案与独立DB切换说明（Issue #53）
+
+## 1. 默认行为（已切换）
+- 默认源档案：`speedx_bundle`
+- 默认抓取三条 feed：
+  - `TheSpeedX/http` -> `http.txt`
+  - `TheSpeedX/socks4` -> `socks4.txt`
+  - `TheSpeedX/socks5` -> `socks5.txt`
+- 默认数据库：`apps/proxy-pool-service/data/proxyhub-speedx-bundle.db`
+
+## 2. 旧源封存
+- 保留档案：`monosans_archive`
+- 配置保留，但默认不参与抓取（封存状态）。
+- 旧数据库保留：`apps/proxy-pool-service/data/proxyhub-v1.db`
+
+## 3. 源档案与数据库映射
+- `speedx_bundle` -> `proxyhub-speedx-bundle.db`
+- `monosans_archive` -> `proxyhub-v1.db`
+
+数据库路径选择优先级：
+1. `PROXY_HUB_DB_PATH`（最高优先级，手工强制指定）
+2. 当前 `PROXY_HUB_SOURCE_PROFILE` 对应档案的内置 `dbPath`
+
+## 4. 运行时切换
+- 切换源档案：`PROXY_HUB_SOURCE_PROFILE`
+- 可选值：`speedx_bundle`、`monosans_archive`
+
+## 5. 兼容开关（单源调试）
+以下环境变量仍保留，但定位为“单源调试用途”（非默认生产路径）：
+- `PROXY_HUB_SOURCE_NAME`
+- `PROXY_HUB_SOURCE_URL`
+- `PROXY_HUB_SOURCE_ENABLED`
+- `PROXY_HUB_SOURCE_DEFAULT_PROTOCOL`
+- `PROXY_HUB_SOURCE_FORMAT`
+
+当上述任一变量被设置时，程序会进入“单源覆盖模式”，不走 profile 三源打包抓取。


### PR DESCRIPTION
﻿## Summary
- source model upgraded to profile-based config (`activeProfile + profiles + activeFeeds`)
- default source switched to `speedx_bundle` with 3 feeds in one cycle:
  - TheSpeedX/http (`http.txt`)
  - TheSpeedX/socks4 (`socks4.txt`)
  - TheSpeedX/socks5 (`socks5.txt`)
- monosans kept as archived profile (`monosans_archive`), no longer default
- db path now auto-resolves by active source profile (unless `PROXY_HUB_DB_PATH` is explicitly set)
- engine source cycle now iterates feeds and performs one unified validation cycle at end of round
- protocol allow-list includes `socks4`
- legacy `PROXY_HUB_SOURCE_*` variables remain as single-source debug override path

## Why
The issue was expanded from “line format support” to full operational switch:
- three SpeedX feeds must be fetched together
- default source must switch
- each source profile must have isolated DB mapping

## Validation
- `npm run test:proxyhub:unit`
- `npm run test:proxyhub:coverage`
  - statements: 100
  - lines: 100
  - functions: 100
  - branches: 98.2

## Docs
- added: `docs/22_模块18_源档案与独立DB切换说明.md`

Fixes #53
