### PR TITLE
fix(proxyhub): #57 /proxy-admin 统计口径统一排除退役并新增新兵训练营

### DIFF
--- a/apps/proxy-pool-service/src/db.js
+++ b/apps/proxy-pool-service/src/db.js
@@ -1064,7 +1064,7 @@ class ProxyHubDb {
     }
 
     // 0187_getProxyList_获取代理列表逻辑
-    getProxyList({ limit = 200, rank, lifecycle } = {}) {
+    getProxyList({ limit = 200, rank, lifecycle, excludeRetired = false } = {}) {
         const clauses = [];
         const params = {};
 
@@ -1075,6 +1075,9 @@ class ProxyHubDb {
         if (lifecycle) {
             clauses.push('lifecycle = @lifecycle');
             params.lifecycle = lifecycle;
+        }
+        if (excludeRetired) {
+            clauses.push("lifecycle != 'retired'");
         }
 
         const where = clauses.length ? `WHERE ${clauses.join(' AND ')}` : '';
@@ -1095,13 +1098,16 @@ class ProxyHubDb {
     }
 
     // 0017_getRankBoard_获取军衔看板逻辑
-    getRankBoard() {
+    getRankBoard(options = {}) {
+        const excludeRetired = options.excludeRetired === true;
+        const where = excludeRetired ? "WHERE lifecycle != 'retired'" : '';
         return this.db.prepare(`
             SELECT rank, COUNT(*) AS count,
                 ROUND(AVG(health_score), 2) AS avgHealth,
                 ROUND(AVG(combat_points), 2) AS avgCombat,
                 ROUND(AVG(ip_value_score), 2) AS avgValue
             FROM proxies
+            ${where}
             GROUP BY rank
             ORDER BY CASE rank
                 WHEN '新兵' THEN 1
@@ -1116,13 +1122,17 @@ class ProxyHubDb {
     }
 
     // 0197_getValueBoard_获取价值榜逻辑
-    getValueBoard(limit = 100, lifecycle) {
+    getValueBoard(limit = 100, lifecycle, options = {}) {
         const safeLimit = Math.max(1, Math.min(500, Number(limit) || 100));
         const clauses = [];
         const params = { limit: safeLimit };
+        const excludeRetired = options.excludeRetired === true;
         if (lifecycle) {
             clauses.push('lifecycle = @lifecycle');
             params.lifecycle = String(lifecycle);
+        }
+        if (excludeRetired) {
+            clauses.push("lifecycle != 'retired'");
         }
 
         const where = clauses.length ? `WHERE ${clauses.join(' AND ')}` : '';
@@ -1152,6 +1162,32 @@ class ProxyHubDb {
                     : 0,
             };
         });
+    }
+
+    // 0268_getRecruitCampBoard_获取新兵训练营分布逻辑
+    getRecruitCampBoard() {
+        const rows = this.db.prepare(`
+            SELECT lifecycle, COUNT(*) AS count
+            FROM proxies
+            WHERE rank = '新兵'
+              AND lifecycle IN ('active', 'reserve', 'candidate')
+            GROUP BY lifecycle
+        `).all();
+
+        const counters = {
+            active: 0,
+            reserve: 0,
+            candidate: 0,
+        };
+        for (const row of rows) {
+            counters[row.lifecycle] = Number(row.count) || 0;
+        }
+
+        return [
+            { lifecycle: 'active', label: '新兵连', count: counters.active },
+            { lifecycle: 'reserve', label: '医务室', count: counters.reserve },
+            { lifecycle: 'candidate', label: '预备队', count: counters.candidate },
+        ];
     }
 
     // 0188_getHonors_获取荣誉逻辑
@@ -1289,20 +1325,26 @@ class ProxyHubDb {
     }
 
     // 0018_getSourceDistribution_获取来源分布逻辑
-    getSourceDistribution() {
+    getSourceDistribution(options = {}) {
+        const excludeRetired = options.excludeRetired === true;
+        const where = excludeRetired ? "WHERE lifecycle != 'retired'" : '';
         return this.db.prepare(`
             SELECT source, COUNT(*) AS count
             FROM proxies
+            ${where}
             GROUP BY source
             ORDER BY count DESC
         `).all();
     }
 
     // 0019_getLifecycleDistribution_获取分布逻辑
-    getLifecycleDistribution() {
+    getLifecycleDistribution(options = {}) {
+        const excludeRetired = options.excludeRetired === true;
+        const where = excludeRetired ? "WHERE lifecycle != 'retired'" : '';
         return this.db.prepare(`
             SELECT lifecycle, COUNT(*) AS count
             FROM proxies
+            ${where}
             GROUP BY lifecycle
         `).all();
     }

--- a/apps/proxy-pool-service/src/db.test.js
+++ b/apps/proxy-pool-service/src/db.test.js
@@ -310,6 +310,62 @@ test('getRankBoard should keep 校官 and 将官 in canonical order', () => {
     cleanup(h);
 });
 
+test('excludeRetired filters should apply to boards, lists and distributions; recruit camp should split new recruits', () => {
+    const h = createDb();
+    const now = new Date().toISOString();
+
+    h.db.upsertSourceBatch(
+        [
+            { ip: '31.0.0.1', port: 80, protocol: 'http' },
+            { ip: '31.0.0.2', port: 80, protocol: 'http' },
+            { ip: '31.0.0.3', port: 80, protocol: 'http' },
+            { ip: '31.0.0.4', port: 80, protocol: 'http' },
+            { ip: '31.0.0.5', port: 80, protocol: 'http' },
+        ],
+        (() => {
+            let i = 0;
+            return () => `训练营-${++i}`;
+        })(),
+        'src-camp',
+        'batch-camp',
+        now,
+    );
+
+    const proxies = h.db.getProxyList({ limit: 20 });
+    h.db.updateProxyById(proxies[0].id, { rank: '新兵', lifecycle: 'active', updated_at: now });
+    h.db.updateProxyById(proxies[1].id, { rank: '新兵', lifecycle: 'reserve', updated_at: now });
+    h.db.updateProxyById(proxies[2].id, { rank: '新兵', lifecycle: 'candidate', updated_at: now });
+    h.db.updateProxyById(proxies[3].id, { rank: '新兵', lifecycle: 'retired', updated_at: now });
+    h.db.updateProxyById(proxies[4].id, { rank: '士官', lifecycle: 'retired', updated_at: now });
+
+    const rankBoardAll = h.db.getRankBoard();
+    const rankBoardFiltered = h.db.getRankBoard({ excludeRetired: true });
+    const rankAllNewbie = rankBoardAll.find((x) => x.rank === '新兵')?.count || 0;
+    const rankFilteredNewbie = rankBoardFiltered.find((x) => x.rank === '新兵')?.count || 0;
+    assert.equal(rankAllNewbie, 4);
+    assert.equal(rankFilteredNewbie, 3);
+    assert.equal(rankBoardFiltered.some((x) => x.rank === '士官'), false);
+
+    const lifecycleFiltered = h.db.getLifecycleDistribution({ excludeRetired: true });
+    assert.equal(lifecycleFiltered.some((x) => x.lifecycle === 'retired'), false);
+
+    const sourceFiltered = h.db.getSourceDistribution({ excludeRetired: true });
+    assert.equal(sourceFiltered.length >= 1, true);
+
+    const listFiltered = h.db.getProxyList({ limit: 20, excludeRetired: true });
+    assert.equal(listFiltered.some((x) => x.lifecycle === 'retired'), false);
+
+    const valueFiltered = h.db.getValueBoard(20, undefined, { excludeRetired: true });
+    assert.equal(valueFiltered.some((x) => x.lifecycle === 'retired'), false);
+
+    const camp = h.db.getRecruitCampBoard();
+    assert.equal(camp.find((x) => x.lifecycle === 'active')?.count, 1);
+    assert.equal(camp.find((x) => x.lifecycle === 'reserve')?.count, 1);
+    assert.equal(camp.find((x) => x.lifecycle === 'candidate')?.count, 1);
+
+    cleanup(h);
+});
+
 test('value board API should sort by value and parse breakdown and honor fields', () => {
     const h = createDb();
     const now = new Date().toISOString();

--- a/apps/proxy-pool-service/src/engine.test.js
+++ b/apps/proxy-pool-service/src/engine.test.js
@@ -282,6 +282,7 @@ test('engine utility functions should cover helper branches', async () => {
 
 test('engine start/stop should be idempotent and persist snapshot', async () => {
     const h = createDbHandle();
+    h.config.storage.snapshotRetentionDays = 0;
     const logger = createLogger();
 
     const workerPool = {

--- a/apps/proxy-pool-service/src/server.js
+++ b/apps/proxy-pool-service/src/server.js
@@ -28,6 +28,15 @@ function normalizeLimit(value, fallback, min, max) {
     return Math.max(min, Math.min(max, normalized));
 }
 
+// 0268_normalizeBooleanFlag_规范化布尔开关逻辑
+function normalizeBooleanFlag(value, fallback = false) {
+    if (value == null) return fallback;
+    const text = String(value).trim().toLowerCase();
+    if (['1', 'true', 'yes', 'on'].includes(text)) return true;
+    if (['0', 'false', 'no', 'off'].includes(text)) return false;
+    return fallback;
+}
+
 // 0093_createRuntime_创建运行时逻辑
 function createRuntime(options = {}) {
     const config = options.config || defaultConfig;
@@ -103,12 +112,24 @@ function createRuntime(options = {}) {
         res.type('html').send(renderRuntimeLogsPage());
     });
 
-    app.get('/v1/proxies/pool-status', (_req, res) => {
+    app.get('/v1/proxies/pool-status', (req, res) => {
+        const excludeRetired = normalizeBooleanFlag(req.query.excludeRetired, false);
+        const sourceDistribution = db.getSourceDistribution({ excludeRetired });
+        const lifecycleDistribution = db.getLifecycleDistribution({ excludeRetired });
+        let latestSnapshot = db.getLatestSnapshot();
+        if (excludeRetired && latestSnapshot) {
+            latestSnapshot = {
+                ...latestSnapshot,
+                source_distribution: sourceDistribution,
+                rank_distribution: db.getRankBoard({ excludeRetired }),
+                lifecycle_distribution: lifecycleDistribution,
+            };
+        }
         res.json({
             poolStatus: workerPool.getStatus(),
-            sourceDistribution: db.getSourceDistribution(),
-            lifecycleDistribution: db.getLifecycleDistribution(),
-            latestSnapshot: db.getLatestSnapshot(),
+            sourceDistribution,
+            lifecycleDistribution,
+            latestSnapshot,
         });
     });
 
@@ -116,9 +137,10 @@ function createRuntime(options = {}) {
         const limit = normalizeLimit(req.query.limit, 200, 1, 500);
         const rank = req.query.rank ? String(req.query.rank) : undefined;
         const lifecycle = req.query.lifecycle ? String(req.query.lifecycle) : undefined;
+        const excludeRetired = normalizeBooleanFlag(req.query.excludeRetired, false);
 
         res.json({
-            items: db.getProxyList({ limit, rank, lifecycle }),
+            items: db.getProxyList({ limit, rank, lifecycle, excludeRetired }),
         });
     });
 
@@ -139,8 +161,9 @@ function createRuntime(options = {}) {
     app.get('/v1/proxies/value-board', (req, res) => {
         const limit = normalizeLimit(req.query.limit, 100, 1, 500);
         const lifecycle = req.query.lifecycle ? String(req.query.lifecycle) : undefined;
+        const excludeRetired = normalizeBooleanFlag(req.query.excludeRetired, false);
         res.json({
-            items: db.getValueBoard(limit, lifecycle),
+            items: db.getValueBoard(limit, lifecycle, { excludeRetired }),
         });
     });
 
@@ -359,9 +382,16 @@ function createRuntime(options = {}) {
         });
     });
 
-    app.get('/v1/proxies/ranks/board', (_req, res) => {
+    app.get('/v1/proxies/ranks/board', (req, res) => {
+        const excludeRetired = normalizeBooleanFlag(req.query.excludeRetired, false);
         res.json({
-            items: db.getRankBoard(),
+            items: db.getRankBoard({ excludeRetired }),
+        });
+    });
+
+    app.get('/v1/proxies/recruit-camp', (_req, res) => {
+        res.json({
+            items: db.getRecruitCampBoard(),
         });
     });
 

--- a/apps/proxy-pool-service/src/server.test.js
+++ b/apps/proxy-pool-service/src/server.test.js
@@ -124,6 +124,11 @@ function createStubs() {
         getBattleTestRuns: () => [{ id: 6, stage: 'l1' }],
         getValueBoard: () => [{ id: 7, ip_value_score: 88.8 }],
         getRankBoard: () => [{ rank: '新兵', count: 1 }],
+        getRecruitCampBoard: () => [
+            { lifecycle: 'active', label: '新兵连', count: 1 },
+            { lifecycle: 'reserve', label: '医务室', count: 0 },
+            { lifecycle: 'candidate', label: '预备队', count: 2 },
+        ],
         getHonors: () => [{ id: 3 }],
         getRetirements: () => [{ id: 4 }],
         getActiveCount: () => 60,
@@ -243,6 +248,7 @@ test('server runtime should expose all REST endpoints and shutdown cleanly', asy
         '/v1/proxies/rollout/orchestrator/events',
         '/v1/proxies/candidate-control',
         '/v1/proxies/ranks/board',
+        '/v1/proxies/recruit-camp',
         '/v1/proxies/honors?limit=1000',
         '/v1/proxies/retirements?limit=-1',
         '/v1/runtime/logs?limit=abc',
@@ -374,6 +380,80 @@ test('server runtime should expose all REST endpoints and shutdown cleanly', asy
     assert.equal(stubs.state.dbClosed, true);
     assert.equal(stubs.state.poolClosed, true);
     assert.equal(stubs.state.engineStopped, true);
+});
+
+test('excludeRetired flag should be forwarded to admin stats endpoints', async () => {
+    const stubs = createStubs();
+    const calls = {
+        source: [],
+        lifecycle: [],
+        rank: [],
+        list: [],
+        value: [],
+    };
+
+    stubs.db.getSourceDistribution = (options) => {
+        calls.source.push(options);
+        return [{ source: 'filtered-source', count: 1 }];
+    };
+    stubs.db.getLifecycleDistribution = (options) => {
+        calls.lifecycle.push(options);
+        return [{ lifecycle: 'active', count: 1 }];
+    };
+    stubs.db.getLatestSnapshot = () => ({
+        workers_total: 2,
+        source_distribution: [{ source: 'legacy-source', count: 9 }],
+        rank_distribution: [{ rank: '新兵', count: 9 }],
+        lifecycle_distribution: [{ lifecycle: 'retired', count: 9 }],
+    });
+    stubs.db.getRankBoard = (options) => {
+        calls.rank.push(options);
+        return [{ rank: '新兵', count: 1 }];
+    };
+    stubs.db.getProxyList = (options) => {
+        calls.list.push(options);
+        return [];
+    };
+    stubs.db.getValueBoard = (limit, lifecycle, options) => {
+        calls.value.push({ limit, lifecycle, options });
+        return [];
+    };
+    stubs.db.getRecruitCampBoard = () => [
+        { lifecycle: 'active', label: '新兵连', count: 1 },
+        { lifecycle: 'reserve', label: '医务室', count: 2 },
+        { lifecycle: 'candidate', label: '预备队', count: 3 },
+    ];
+
+    const { runtime, baseUrl } = await startRuntimeOnRandomPort(stubs);
+    try {
+        const poolStatusRes = await fetch(baseUrl + '/v1/proxies/pool-status?excludeRetired=true');
+        const poolStatus = await poolStatusRes.json();
+        await fetch(baseUrl + '/v1/proxies/ranks/board?excludeRetired=true');
+        await fetch(baseUrl + '/v1/proxies/list?limit=20&excludeRetired=true');
+        await fetch(baseUrl + '/v1/proxies/value-board?limit=20&excludeRetired=true');
+        await fetch(baseUrl + '/v1/proxies/list?limit=20&excludeRetired=off');
+        await fetch(baseUrl + '/v1/proxies/list?limit=20&excludeRetired=not-bool');
+        const campRes = await fetch(baseUrl + '/v1/proxies/recruit-camp');
+        const camp = await campRes.json();
+
+        assert.equal(calls.source.at(-1).excludeRetired, true);
+        assert.equal(calls.lifecycle.at(-1).excludeRetired, true);
+        assert.equal(calls.rank.at(-2).excludeRetired, true);
+        assert.equal(calls.list.at(-3).excludeRetired, true);
+        assert.equal(calls.list.at(-2).excludeRetired, false);
+        assert.equal(calls.list.at(-1).excludeRetired, false);
+        assert.equal(calls.value.at(-1).options.excludeRetired, true);
+        assert.deepEqual(poolStatus.latestSnapshot.source_distribution, [{ source: 'filtered-source', count: 1 }]);
+        assert.deepEqual(poolStatus.latestSnapshot.rank_distribution, [{ rank: '新兵', count: 1 }]);
+        assert.deepEqual(poolStatus.latestSnapshot.lifecycle_distribution, [{ lifecycle: 'active', count: 1 }]);
+        assert.equal(camp.items.length, 3);
+        assert.equal(camp.items[0].lifecycle, 'active');
+
+        await fetch(baseUrl + '/v1/proxies/ranks/board');
+        assert.equal(calls.rank.at(-1).excludeRetired, false);
+    } finally {
+        await runtime.shutdown('TEST-EXCLUDE-RETIRED');
+    }
 });
 
 test('rollout rollback endpoint should skip apply when guardrails are healthy', async () => {

--- a/apps/proxy-pool-service/src/views/proxy-admin.html
+++ b/apps/proxy-pool-service/src/views/proxy-admin.html
@@ -65,7 +65,7 @@
     </section>
 
     <section class="card">
-      <h2>来源分布 / 生命周期 / 军衔分布</h2>
+      <h2>来源分布 / 生命周期 / 现役军衔分布 / 新兵训练营</h2>
       <div class="content"><div id="distributions"></div></div>
     </section>
 
@@ -164,10 +164,21 @@ function renderDistributions(snapshot) {
   const src = (snapshot.sourceDistribution || []).map(function(x){ return '<span class="pill">' + esc(x.source) + ': ' + x.count + '</span>'; }).join('');
   const life = (snapshot.lifecycleDistribution || []).map(function(x){ return '<span class="pill">' + esc(x.lifecycle) + ': ' + x.count + '</span>'; }).join('');
   const rank = (snapshot.rankBoard || []).map(function(x){ return '<span class="pill">' + esc(x.rank) + ': ' + x.count + '</span>'; }).join('');
+  const recruitMap = { active: 0, reserve: 0, candidate: 0 };
+  (snapshot.recruitCamp || []).forEach(function(x){
+    if (x && Object.prototype.hasOwnProperty.call(recruitMap, x.lifecycle)) {
+      recruitMap[x.lifecycle] = Number(x.count || 0);
+    }
+  });
+  const recruit = ''
+    + '<span class="pill">active(新兵连): ' + recruitMap.active + '</span>'
+    + '<span class="pill">reserve(医务室): ' + recruitMap.reserve + '</span>'
+    + '<span class="pill">candidate(预备队): ' + recruitMap.candidate + '</span>';
   distributions.innerHTML = ''
     + '<div><strong>来源分布</strong><div>' + (src || '-') + '</div></div>'
     + '<div style="margin-top:8px"><strong>生命周期</strong><div>' + (life || '-') + '</div></div>'
-    + '<div style="margin-top:8px"><strong>军衔分布</strong><div>' + (rank || '-') + '</div></div>';
+    + '<div style="margin-top:8px"><strong>现役军衔分布</strong><div>' + (rank || '-') + '</div></div>'
+    + '<div style="margin-top:8px"><strong>新兵训练营</strong><div>' + recruit + '</div></div>';
 }
 
 function renderSimpleTable(el, headers, rows) {
@@ -184,26 +195,33 @@ function renderSimpleTable(el, headers, rows) {
 
 async function loadAll() {
   const data = await Promise.all([
-    fetch('/v1/proxies/pool-status').then(function(r){ return r.json(); }),
-    fetch('/v1/proxies/ranks/board').then(function(r){ return r.json(); }),
+    fetch('/v1/proxies/pool-status?excludeRetired=true').then(function(r){ return r.json(); }),
+    fetch('/v1/proxies/ranks/board?excludeRetired=true').then(function(r){ return r.json(); }),
+    fetch('/v1/proxies/recruit-camp').then(function(r){ return r.json(); }),
     fetch('/v1/proxies/honors?limit=30').then(function(r){ return r.json(); }),
     fetch('/v1/proxies/retirements?limit=30').then(function(r){ return r.json(); }),
-    fetch('/v1/proxies/value-board?limit=100').then(function(r){ return r.json(); }),
+    fetch('/v1/proxies/value-board?limit=100&excludeRetired=true').then(function(r){ return r.json(); }),
     fetch('/v1/proxies/policy').then(function(r){ return r.json(); }),
     fetch('/v1/proxies/events?limit=50').then(function(r){ return r.json(); }),
-    fetch('/v1/proxies/list?limit=50').then(function(r){ return r.json(); }),
+    fetch('/v1/proxies/list?limit=50&excludeRetired=true').then(function(r){ return r.json(); }),
   ]);
 
   const pool = data[0];
   const ranks = data[1];
-  const honors = data[2];
-  const retires = data[3];
-  const values = data[4];
-  const policyPayload = data[5];
-  const events = data[6];
-  const proxies = data[7];
+  const recruitCamp = data[2];
+  const honors = data[3];
+  const retires = data[4];
+  const values = data[5];
+  const policyPayload = data[6];
+  const events = data[7];
+  const proxies = data[8];
   renderPool(pool.poolStatus);
-  renderDistributions({ sourceDistribution: pool.sourceDistribution, lifecycleDistribution: pool.lifecycleDistribution, rankBoard: ranks.items });
+  renderDistributions({
+    sourceDistribution: pool.sourceDistribution,
+    lifecycleDistribution: pool.lifecycleDistribution,
+    rankBoard: ranks.items,
+    recruitCamp: recruitCamp.items,
+  });
 
   renderSimpleTable(honorTable, ['时间', '代理', '荣誉', '状态', '原因'], (honors.items || []).map(function(x){
     return '<tr><td class="mono">' + esc(x.awarded_at) + '</td><td>' + esc(x.display_name) + '</td><td>' + esc(x.honor_type) + '</td><td class="' + (x.active ? 'ok' : 'warn') + '">' + (x.active ? '激活' : '历史') + '</td><td>' + esc(x.reason || '-') + '</td></tr>';


### PR DESCRIPTION
﻿## Summary
Implement #57 updated scope for `/proxy-admin` metric consistency:
- unify admin statistics/list boards to exclude `retired` when requested
- add recruit-camp split panel for `新兵` lifecycle buckets
- keep API backward compatibility (`excludeRetired` defaults to `false`)

## Changes
1. Data layer
- add `excludeRetired` support to:
  - `getSourceDistribution(options)`
  - `getLifecycleDistribution(options)`
  - `getProxyList({ ..., excludeRetired })`
  - `getRankBoard(options)`
  - `getValueBoard(limit, lifecycle, options)`
- add `getRecruitCampBoard()` returning:
  - `active(新兵连)`
  - `reserve(医务室)`
  - `candidate(预备队)`

2. API layer
- add query parsing helper for boolean flags
- support `excludeRetired` on:
  - `GET /v1/proxies/pool-status`
  - `GET /v1/proxies/ranks/board`
  - `GET /v1/proxies/value-board`
  - `GET /v1/proxies/list`
- add endpoint:
  - `GET /v1/proxies/recruit-camp`

3. Admin view
- update header and section label to `现役军衔分布`
- add `新兵训练营` block
- admin fetches now call:
  - `/v1/proxies/pool-status?excludeRetired=true`
  - `/v1/proxies/ranks/board?excludeRetired=true`
  - `/v1/proxies/value-board?limit=100&excludeRetired=true`
  - `/v1/proxies/list?limit=50&excludeRetired=true`
  - `/v1/proxies/recruit-camp`

4. Tests
- add DB regression coverage for exclude-retired filtering and recruit-camp counts
- add server endpoint tests for forwarding/compatibility of `excludeRetired`
- stabilize one existing engine unit test against calendar drift (retention date boundary)

## Validation
- `npm run test:proxyhub:unit` ✅
- `npm run test:proxyhub:coverage` ✅
  - branches: `98.17%` (threshold `98%`)

Closes #57
