### PR TITLE
fix(proxyhub): remove retirements/proxy-detail panels from /proxy-admin

### DIFF
--- a/apps/proxy-pool-service/src/views/proxy-admin.html
+++ b/apps/proxy-pool-service/src/views/proxy-admin.html
@@ -70,9 +70,7 @@
     </section>
 
     <section class="card"><h2>荣誉墙</h2><div class="content"><table id="honorTable"></table></div></section>
-    <section class="card"><h2>退伍台账</h2><div class="content"><table id="retireTable"></table></div></section>
     <section class="card"><h2>事件流</h2><div class="content"><table id="eventTable"></table></div></section>
-    <section class="card"><h2>代理明细（前50）</h2><div class="content"><table id="proxyTable"></table></div></section>
   </main>
 
   <section class="wide-section">
@@ -89,10 +87,8 @@ const workerTable = document.getElementById('workerTable');
 const poolStats = document.getElementById('poolStats');
 const distributions = document.getElementById('distributions');
 const honorTable = document.getElementById('honorTable');
-const retireTable = document.getElementById('retireTable');
 const valueBoardTable = document.getElementById('valueBoardTable');
 const eventTable = document.getElementById('eventTable');
-const proxyTable = document.getElementById('proxyTable');
 
 const FALLBACK_RANK_ORDER = ['新兵', '列兵', '士官', '尉官', '校官', '将官', '王牌'];
 
@@ -199,22 +195,18 @@ async function loadAll() {
     fetch('/v1/proxies/ranks/board?excludeRetired=true').then(function(r){ return r.json(); }),
     fetch('/v1/proxies/recruit-camp').then(function(r){ return r.json(); }),
     fetch('/v1/proxies/honors?limit=30').then(function(r){ return r.json(); }),
-    fetch('/v1/proxies/retirements?limit=30').then(function(r){ return r.json(); }),
     fetch('/v1/proxies/value-board?limit=100&excludeRetired=true').then(function(r){ return r.json(); }),
     fetch('/v1/proxies/policy').then(function(r){ return r.json(); }),
     fetch('/v1/proxies/events?limit=50').then(function(r){ return r.json(); }),
-    fetch('/v1/proxies/list?limit=50&excludeRetired=true').then(function(r){ return r.json(); }),
   ]);
 
   const pool = data[0];
   const ranks = data[1];
   const recruitCamp = data[2];
   const honors = data[3];
-  const retires = data[4];
-  const values = data[5];
-  const policyPayload = data[6];
-  const events = data[7];
-  const proxies = data[8];
+  const values = data[4];
+  const policyPayload = data[5];
+  const events = data[6];
   renderPool(pool.poolStatus);
   renderDistributions({
     sourceDistribution: pool.sourceDistribution,
@@ -225,10 +217,6 @@ async function loadAll() {
 
   renderSimpleTable(honorTable, ['时间', '代理', '荣誉', '状态', '原因'], (honors.items || []).map(function(x){
     return '<tr><td class="mono">' + esc(x.awarded_at) + '</td><td>' + esc(x.display_name) + '</td><td>' + esc(x.honor_type) + '</td><td class="' + (x.active ? 'ok' : 'warn') + '">' + (x.active ? '激活' : '历史') + '</td><td>' + esc(x.reason || '-') + '</td></tr>';
-  }));
-
-  renderSimpleTable(retireTable, ['时间', '代理', '类型', '原因'], (retires.items || []).map(function(x){
-    return '<tr><td class="mono">' + esc(x.retired_at) + '</td><td>' + esc(x.display_name) + '</td><td class="warn">' + esc(x.retired_type) + '</td><td>' + esc(x.reason || '-') + '</td></tr>';
   }));
 
   const rankHelp = buildRankHelp(policyPayload && policyPayload.policy && policyPayload.policy.ranks);
@@ -258,10 +246,6 @@ async function loadAll() {
 
   renderSimpleTable(eventTable, ['时间', '类型', '代理', '消息'], (events.items || []).map(function(x){
     return '<tr><td class="mono">' + esc(x.timestamp) + '</td><td>' + esc(x.event_type) + '</td><td>' + esc(x.display_name || '-') + '</td><td>' + esc(x.message) + '</td></tr>';
-  }));
-
-  renderSimpleTable(proxyTable, ['昵称', '地址', '来源', '生命周期', '军衔', '价值分', '战功', '健康', '纪律', '样本'], (proxies.items || []).map(function(x){
-    return '<tr><td>' + esc(x.display_name) + '</td><td class="mono">' + esc(x.ip + ':' + x.port + '/' + x.protocol) + '</td><td>' + esc(x.source) + '</td><td>' + esc(x.lifecycle) + '</td><td>' + esc(x.rank) + '</td><td class="ok">' + fmt(Number(x.ip_value_score || 0).toFixed(2)) + '</td><td>' + fmt(x.combat_points) + '</td><td>' + fmt(x.health_score) + '</td><td>' + fmt(x.discipline_score) + '</td><td>' + fmt(x.total_samples) + '</td></tr>';
   }));
 }
 


### PR DESCRIPTION
## Summary
Implement #55 by removing high-density detail panels from `/proxy-admin` while keeping backend APIs intact.

## Changes
- Remove **����̨��** panel from admin page layout.
- Remove **������ϸ��ǰ50��** panel from admin page layout.
- Stop querying retired ledger and proxy list endpoints from the admin page JS.
- Remove corresponding front-end table bindings/rendering logic only.

## Scope Guard
- No backend endpoint deletion or behavior changes.
- Aggregated boards remain unchanged (pool status, distributions, honors, events, value board).

## Validation
- `npm run test:proxyhub:unit` ?
- `npm run test:proxyhub:coverage` ?
  - branches: `98.17%` (threshold `98%`)

Closes #55