### PR TITLE
feat(proxyhub): add retired column to recruit camp panel

### DIFF
--- a/apps/proxy-pool-service/src/db.js
+++ b/apps/proxy-pool-service/src/db.js
@@ -1169,8 +1169,8 @@ class ProxyHubDb {
         const rows = this.db.prepare(`
             SELECT lifecycle, COUNT(*) AS count
             FROM proxies
-            WHERE rank = '新兵'
-              AND lifecycle IN ('active', 'reserve', 'candidate')
+            WHERE (rank = '新兵' AND lifecycle IN ('active', 'reserve', 'candidate'))
+               OR lifecycle = 'retired'
             GROUP BY lifecycle
         `).all();
 
@@ -1178,6 +1178,7 @@ class ProxyHubDb {
             active: 0,
             reserve: 0,
             candidate: 0,
+            retired: 0,
         };
         for (const row of rows) {
             counters[row.lifecycle] = Number(row.count) || 0;
@@ -1187,6 +1188,7 @@ class ProxyHubDb {
             { lifecycle: 'active', label: '新兵连', count: counters.active },
             { lifecycle: 'reserve', label: '医务室', count: counters.reserve },
             { lifecycle: 'candidate', label: '预备队', count: counters.candidate },
+            { lifecycle: 'retired', label: '已退役', count: counters.retired },
         ];
     }
 

--- a/apps/proxy-pool-service/src/db.test.js
+++ b/apps/proxy-pool-service/src/db.test.js
@@ -362,6 +362,7 @@ test('excludeRetired filters should apply to boards, lists and distributions; re
     assert.equal(camp.find((x) => x.lifecycle === 'active')?.count, 1);
     assert.equal(camp.find((x) => x.lifecycle === 'reserve')?.count, 1);
     assert.equal(camp.find((x) => x.lifecycle === 'candidate')?.count, 1);
+    assert.equal(camp.find((x) => x.lifecycle === 'retired')?.count, 2);
 
     cleanup(h);
 });

--- a/apps/proxy-pool-service/src/server.test.js
+++ b/apps/proxy-pool-service/src/server.test.js
@@ -128,6 +128,7 @@ function createStubs() {
             { lifecycle: 'active', label: '新兵连', count: 1 },
             { lifecycle: 'reserve', label: '医务室', count: 0 },
             { lifecycle: 'candidate', label: '预备队', count: 2 },
+            { lifecycle: 'retired', label: '已退役', count: 3 },
         ],
         getHonors: () => [{ id: 3 }],
         getRetirements: () => [{ id: 4 }],
@@ -422,6 +423,7 @@ test('excludeRetired flag should be forwarded to admin stats endpoints', async (
         { lifecycle: 'active', label: '新兵连', count: 1 },
         { lifecycle: 'reserve', label: '医务室', count: 2 },
         { lifecycle: 'candidate', label: '预备队', count: 3 },
+        { lifecycle: 'retired', label: '已退役', count: 4 },
     ];
 
     const { runtime, baseUrl } = await startRuntimeOnRandomPort(stubs);
@@ -446,8 +448,9 @@ test('excludeRetired flag should be forwarded to admin stats endpoints', async (
         assert.deepEqual(poolStatus.latestSnapshot.source_distribution, [{ source: 'filtered-source', count: 1 }]);
         assert.deepEqual(poolStatus.latestSnapshot.rank_distribution, [{ rank: '新兵', count: 1 }]);
         assert.deepEqual(poolStatus.latestSnapshot.lifecycle_distribution, [{ lifecycle: 'active', count: 1 }]);
-        assert.equal(camp.items.length, 3);
+        assert.equal(camp.items.length, 4);
         assert.equal(camp.items[0].lifecycle, 'active');
+        assert.equal(camp.items.find((x) => x.lifecycle === 'retired')?.count, 4);
 
         await fetch(baseUrl + '/v1/proxies/ranks/board');
         assert.equal(calls.rank.at(-1).excludeRetired, false);

--- a/apps/proxy-pool-service/src/views/proxy-admin.html
+++ b/apps/proxy-pool-service/src/views/proxy-admin.html
@@ -164,7 +164,7 @@ function renderDistributions(snapshot) {
   const src = (snapshot.sourceDistribution || []).map(function(x){ return '<span class="pill">' + esc(x.source) + ': ' + x.count + '</span>'; }).join('');
   const life = (snapshot.lifecycleDistribution || []).map(function(x){ return '<span class="pill">' + esc(x.lifecycle) + ': ' + x.count + '</span>'; }).join('');
   const rank = (snapshot.rankBoard || []).map(function(x){ return '<span class="pill">' + esc(x.rank) + ': ' + x.count + '</span>'; }).join('');
-  const recruitMap = { active: 0, reserve: 0, candidate: 0 };
+  const recruitMap = { active: 0, reserve: 0, candidate: 0, retired: 0 };
   (snapshot.recruitCamp || []).forEach(function(x){
     if (x && Object.prototype.hasOwnProperty.call(recruitMap, x.lifecycle)) {
       recruitMap[x.lifecycle] = Number(x.count || 0);
@@ -173,7 +173,8 @@ function renderDistributions(snapshot) {
   const recruit = ''
     + '<span class="pill">active(新兵连): ' + recruitMap.active + '</span>'
     + '<span class="pill">reserve(医务室): ' + recruitMap.reserve + '</span>'
-    + '<span class="pill">candidate(预备队): ' + recruitMap.candidate + '</span>';
+    + '<span class="pill">candidate(预备队): ' + recruitMap.candidate + '</span>'
+    + '<span class="pill">retired(已退役): ' + recruitMap.retired + '</span>';
   distributions.innerHTML = ''
     + '<div><strong>来源分布</strong><div>' + (src || '-') + '</div></div>'
     + '<div style="margin-top:8px"><strong>生命周期</strong><div>' + (life || '-') + '</div></div>'


### PR DESCRIPTION
## Summary
Implement #59 by adding a `retired` slot to the `/proxy-admin` recruit-camp block.

## Changes
1. Data/query layer
- Extend `getRecruitCampBoard()` to return four lifecycle counters:
  - `active(�±���)`
  - `reserve(ҽ����)`
  - `candidate(Ԥ����)`
  - `retired(������)`
- `retired` now counts all records with `lifecycle='retired'` to match dashboard expectation.

2. Admin page
- Recruit-camp UI now renders the new `retired(������)` pill.

3. Tests
- Update DB test for recruit-camp to assert retired count.
- Update server tests/stubs to include 4-item recruit-camp payload and retired assertion.

## Validation
- `npm run test:proxyhub:unit` ?
- `npm run test:proxyhub:coverage` ?
  - branches: `98.17%` (threshold `98%`)

Closes #59