### PR TITLE
fix(proxyhub): recruit camp chinese labels + separate retired block

### DIFF
--- a/apps/proxy-pool-service/src/db.js
+++ b/apps/proxy-pool-service/src/db.js
@@ -1171,8 +1171,8 @@ class ProxyHubDb {
         const rows = this.db.prepare(`
             SELECT lifecycle, COUNT(*) AS count
             FROM proxies
-            WHERE rank = '新兵'
-              AND lifecycle IN ('active', 'reserve', 'candidate', 'retired')
+            WHERE (rank = '新兵' AND lifecycle IN ('active', 'reserve', 'candidate'))
+               OR lifecycle = 'retired'
             GROUP BY lifecycle
         `).all();
 

--- a/apps/proxy-pool-service/src/db.test.js
+++ b/apps/proxy-pool-service/src/db.test.js
@@ -362,7 +362,7 @@ test('excludeRetired filters should apply to boards, lists and distributions; re
     assert.equal(camp.find((x) => x.lifecycle === 'active')?.count, 1);
     assert.equal(camp.find((x) => x.lifecycle === 'reserve')?.count, 1);
     assert.equal(camp.find((x) => x.lifecycle === 'candidate')?.count, 1);
-    assert.equal(camp.find((x) => x.lifecycle === 'retired')?.count, 1);
+    assert.equal(camp.find((x) => x.lifecycle === 'retired')?.count, 2);
 
     cleanup(h);
 });

--- a/apps/proxy-pool-service/src/views.test.js
+++ b/apps/proxy-pool-service/src/views.test.js
@@ -12,7 +12,8 @@ test('renderProxyAdminPage should inject refresh interval', () => {
     assert.equal(html.includes('/v1/proxies/value-board?limit=100'), true);
     assert.equal(html.includes('/v1/proxies/policy'), true);
     assert.equal(html.includes('/v1/proxies/recruit-camp'), true);
-    assert.equal(html.includes('retired(已退役)'), true);
+    assert.equal(html.includes('已退役：'), true);
+    assert.equal(html.includes('active(新兵连)'), false);
     assert.equal(html.includes('退伍台账'), false);
     assert.equal(html.includes('代理明细（前50）'), false);
     assert.equal(html.includes('按价值分从高到低排的名次，1就是当前最有价值的IP。'), true);

--- a/apps/proxy-pool-service/src/views/proxy-admin.html
+++ b/apps/proxy-pool-service/src/views/proxy-admin.html
@@ -65,7 +65,7 @@
     </section>
 
     <section class="card">
-      <h2>来源分布 / 生命周期 / 现役军衔分布 / 新兵训练营</h2>
+      <h2>来源分布 / 生命周期 / 现役军衔分布 / 新兵训练营 / 已退役</h2>
       <div class="content"><div id="distributions"></div></div>
     </section>
 
@@ -160,22 +160,29 @@ function renderDistributions(snapshot) {
   const src = (snapshot.sourceDistribution || []).map(function(x){ return '<span class="pill">' + esc(x.source) + ': ' + x.count + '</span>'; }).join('');
   const life = (snapshot.lifecycleDistribution || []).map(function(x){ return '<span class="pill">' + esc(x.lifecycle) + ': ' + x.count + '</span>'; }).join('');
   const rank = (snapshot.rankBoard || []).map(function(x){ return '<span class="pill">' + esc(x.rank) + ': ' + x.count + '</span>'; }).join('');
-  const recruitMap = { active: 0, reserve: 0, candidate: 0, retired: 0 };
+  const recruitMap = { active: 0, reserve: 0, candidate: 0 };
+  let retiredCount = 0;
   (snapshot.recruitCamp || []).forEach(function(x){
-    if (x && Object.prototype.hasOwnProperty.call(recruitMap, x.lifecycle)) {
+    if (!x) return;
+    if (x.lifecycle === 'retired') {
+      retiredCount = Number(x.count || 0);
+      return;
+    }
+    if (Object.prototype.hasOwnProperty.call(recruitMap, x.lifecycle)) {
       recruitMap[x.lifecycle] = Number(x.count || 0);
     }
   });
   const recruit = ''
-    + '<span class="pill">active(新兵连): ' + recruitMap.active + '</span>'
-    + '<span class="pill">reserve(医务室): ' + recruitMap.reserve + '</span>'
-    + '<span class="pill">candidate(预备队): ' + recruitMap.candidate + '</span>'
-    + '<span class="pill">retired(已退役): ' + recruitMap.retired + '</span>';
+    + '<span class="pill">新兵连：' + recruitMap.active + '</span>'
+    + '<span class="pill">医务室：' + recruitMap.reserve + '</span>'
+    + '<span class="pill">预备队：' + recruitMap.candidate + '</span>';
+  const retired = '<span class="pill">已退役：' + retiredCount + '</span>';
   distributions.innerHTML = ''
     + '<div><strong>来源分布</strong><div>' + (src || '-') + '</div></div>'
     + '<div style="margin-top:8px"><strong>生命周期</strong><div>' + (life || '-') + '</div></div>'
     + '<div style="margin-top:8px"><strong>现役军衔分布</strong><div>' + (rank || '-') + '</div></div>'
-    + '<div style="margin-top:8px"><strong>新兵训练营</strong><div>' + recruit + '</div></div>';
+    + '<div style="margin-top:8px"><strong>新兵训练营</strong><div>' + recruit + '</div></div>'
+    + '<div style="margin-top:8px"><strong>已退役</strong><div>' + retired + '</div></div>';
 }
 
 function renderSimpleTable(el, headers, rows) {


### PR DESCRIPTION
## Summary
Fix #63 for `/proxy-admin` recruit-camp presentation and retired counting semantics.

## Changes
1. New recruit-camp labels are Chinese-only
- `active(�±���)` -> `�±���`
- `reserve(ҽ����)` -> `ҽ����`
- `candidate(Ԥ����)` -> `Ԥ����`

2. Retired moved to a separate peer section
- In distributions card, `������` is rendered as an independent block at the same level as `�±�ѵ��Ӫ`.

3. Retired count uses all ranks
- `getRecruitCampBoard()` now computes:
  - training camp counts from `rank='�±�'` for `active/reserve/candidate`
  - retired count from all records with `lifecycle='retired'` (all ranks)

4. Tests updated
- DB test asserts retired count reflects all-rank retired total.
- View test asserts Chinese-only recruit labels and no `active(�±���)` style text.

## Validation
- `npm run test:proxyhub:unit` ?
- `npm run test:proxyhub:coverage` ?
  - branches: `98.17%` (threshold `98%`)

Closes #63