### PR TITLE
fix(proxyhub): keep feed source names during validation

### DIFF
--- a/apps/proxy-pool-service/src/engine.js
+++ b/apps/proxy-pool-service/src/engine.js
@@ -530,7 +530,7 @@ class ProxyHubEngine extends EventEmitter {
 
         const concurrency = Math.max(2, Math.min(this.config.threadPool.workers * 2, 20));
         await runWithConcurrency(candidates, concurrency, async (proxy) => {
-            await this.processProxy(proxy, sourceName);
+            await this.processProxy(proxy, proxy.source || sourceName);
         });
     }
 

--- a/apps/proxy-pool-service/src/engine.test.js
+++ b/apps/proxy-pool-service/src/engine.test.js
@@ -561,6 +561,10 @@ test('runSourceCycle should fetch multiple active feeds and validate once', asyn
     assert.equal(proxies.length, 3);
     assert.equal(validateCalls, 3);
     assert.equal(proxies.some((item) => item.protocol === 'socks4'), true);
+    assert.equal(proxies.some((item) => item.source === 'TheSpeedX/http'), true);
+    assert.equal(proxies.some((item) => item.source === 'TheSpeedX/socks4'), true);
+    assert.equal(proxies.some((item) => item.source === 'TheSpeedX/socks5'), true);
+    assert.equal(proxies.some((item) => item.source === 'speedx_bundle'), false);
     assert.equal(logger.entries.some((entry) => entry.event === '抓源成功' && entry.ipSource === 'TheSpeedX/socks4'), true);
     assert.equal(logger.entries.some((entry) => entry.event === '等待下一轮' && entry.ipSource === 'speedx_bundle'), true);
 


### PR DESCRIPTION
## Summary
Fix #65 by preserving feed-level source names during validation.

## Root Cause
`runSourceCycle()` called `runValidationCycle(activeProfile)` and `processProxy()` wrote `source: sourceName`, so feed source (e.g. `TheSpeedX/http`) was overwritten by profile key (`speedx_bundle`).

## Changes
1. Validation source propagation
- `runValidationCycle(sourceName)` now calls:
  - `processProxy(proxy, proxy.source || sourceName)`
- This preserves per-proxy feed source when present, and keeps fallback behavior for legacy/empty source rows.

2. Regression tests
- Extend `runSourceCycle should fetch multiple active feeds and validate once`:
  - assert resulting `proxies.source` contains:
    - `TheSpeedX/http`
    - `TheSpeedX/socks4`
    - `TheSpeedX/socks5`
  - assert it does **not** contain `speedx_bundle`

## Validation
- `npm.cmd run test:proxyhub:unit` ?
- `npm.cmd run test:proxyhub:coverage` ?
  - branches: `98.12%` (threshold `98%`)

Closes #65