### PR TITLE
feat(proxyhub): temporarily disable speedx socks4 and purge existing socks4 data

### DIFF
--- a/apps/proxy-pool-service/src/config.js
+++ b/apps/proxy-pool-service/src/config.js
@@ -277,7 +277,12 @@ const sourceProfileRaw = String(process.env.PROXY_HUB_SOURCE_PROFILE || '').trim
 const activeSourceProfile = Object.prototype.hasOwnProperty.call(sourceProfiles, sourceProfileRaw)
     ? sourceProfileRaw
     : 'speedx_bundle';
+const speedxSocks4Enabled = toBool(process.env.PROXY_HUB_SPEEDX_SOCKS4_ENABLED, false);
 const selectedSourceProfile = deepClone(sourceProfiles[activeSourceProfile]);
+const speedxSocks4Feed = selectedSourceProfile.feeds.find((feed) => feed.name === 'TheSpeedX/socks4');
+if (speedxSocks4Feed) {
+    speedxSocks4Feed.enabled = speedxSocks4Enabled;
+}
 
 const hasLegacySourceOverride = hasOwnEnv('PROXY_HUB_SOURCE_NAME')
     || hasOwnEnv('PROXY_HUB_SOURCE_URL')

--- a/apps/proxy-pool-service/src/config.test.js
+++ b/apps/proxy-pool-service/src/config.test.js
@@ -33,6 +33,7 @@ function loadConfigWithEnv(overrides = {}) {
         'PROXY_HUB_SOURCE_DEFAULT_PROTOCOL',
         'PROXY_HUB_SOURCE_FORMAT',
         'PROXY_HUB_SOURCE_PROFILE',
+        'PROXY_HUB_SPEEDX_SOCKS4_ENABLED',
         'PROXY_HUB_DB_PATH',
         ...Object.keys(overrides),
     ]);
@@ -73,6 +74,7 @@ test('config should expose required default values', { concurrency: false }, () 
     assert.equal(Array.isArray(config.source.activeFeeds), true);
     assert.equal(config.source.activeFeeds.length, 3);
     assert.equal(config.source.activeFeeds[0].url.includes('/http.txt'), true);
+    assert.equal(config.source.activeFeeds.some((feed) => feed.name === 'TheSpeedX/socks4' && feed.enabled === false), true);
     assert.equal(config.source.profiles.monosans_archive.enabled, false);
     assert.equal(config.storage.dbPath.includes('proxyhub-speedx-bundle.db'), true);
     assert.equal(config.validation.allowedProtocols.includes('socks4'), true);
@@ -133,6 +135,16 @@ test('config should switch db and feeds by source profile when env profile chang
     assert.equal(config.source.activeFeeds.length, 1);
     assert.equal(config.source.activeFeeds[0].url.includes('proxies.json'), true);
     assert.equal(config.storage.dbPath.includes('proxyhub-v1.db'), true);
+});
+
+test('config should allow re-enable speedx socks4 feed by env switch', { concurrency: false }, () => {
+    const config = loadConfigWithEnv({
+        PROXY_HUB_SOURCE_PROFILE: 'speedx_bundle',
+        PROXY_HUB_SPEEDX_SOCKS4_ENABLED: 'true',
+    });
+
+    assert.equal(config.source.activeProfile, 'speedx_bundle');
+    assert.equal(config.source.activeFeeds.some((feed) => feed.name === 'TheSpeedX/socks4' && feed.enabled === true), true);
 });
 
 test('config should prioritize explicit PROXY_HUB_DB_PATH over profile db mapping', { concurrency: false }, () => {

--- a/apps/proxy-pool-service/src/db.js
+++ b/apps/proxy-pool-service/src/db.js
@@ -1194,6 +1194,50 @@ class ProxyHubDb {
         ];
     }
 
+    // 0270_purgeSocks4Data_清理socks4来源数据逻辑
+    purgeSocks4Data(options = {}) {
+        const sourceName = options.sourceName || 'TheSpeedX/socks4';
+        const protocol = options.protocol || 'socks4';
+
+        const beforeSource = Number(this.db.prepare(`
+            SELECT COUNT(*) AS count
+            FROM proxies
+            WHERE source = ?
+        `).get(sourceName)?.count || 0);
+        const beforeProtocol = Number(this.db.prepare(`
+            SELECT COUNT(*) AS count
+            FROM proxies
+            WHERE protocol = ?
+        `).get(protocol)?.count || 0);
+
+        const deleted = Number(this.db.prepare(`
+            DELETE FROM proxies
+            WHERE source = @sourceName
+               OR protocol = @protocol
+        `).run({ sourceName, protocol }).changes || 0);
+
+        const afterSource = Number(this.db.prepare(`
+            SELECT COUNT(*) AS count
+            FROM proxies
+            WHERE source = ?
+        `).get(sourceName)?.count || 0);
+        const afterProtocol = Number(this.db.prepare(`
+            SELECT COUNT(*) AS count
+            FROM proxies
+            WHERE protocol = ?
+        `).get(protocol)?.count || 0);
+
+        return {
+            sourceName,
+            protocol,
+            deleted,
+            beforeSource,
+            beforeProtocol,
+            afterSource,
+            afterProtocol,
+        };
+    }
+
     // 0188_getHonors_获取荣誉逻辑
     getHonors(limit = 100) {
         return this.db.prepare(`

--- a/apps/proxy-pool-service/src/db.test.js
+++ b/apps/proxy-pool-service/src/db.test.js
@@ -367,6 +367,132 @@ test('excludeRetired filters should apply to boards, lists and distributions; re
     cleanup(h);
 });
 
+test('purgeSocks4Data should delete socks4 source/protocol rows and keep others', () => {
+    const h = createDb();
+    const now = new Date().toISOString();
+    let seq = 0;
+    const nextName = () => `清理-${++seq}`;
+
+    h.db.upsertSourceBatch(
+        [{ ip: '41.0.0.1', port: 80, protocol: 'http' }],
+        nextName,
+        'TheSpeedX/http',
+        'batch-clean-1',
+        now,
+    );
+    h.db.upsertSourceBatch(
+        [{ ip: '41.0.0.2', port: 1080, protocol: 'socks4' }],
+        nextName,
+        'TheSpeedX/socks4',
+        'batch-clean-2',
+        now,
+    );
+    h.db.upsertSourceBatch(
+        [{ ip: '41.0.0.3', port: 1080, protocol: 'socks4' }],
+        nextName,
+        'legacy-socks4-feed',
+        'batch-clean-3',
+        now,
+    );
+    h.db.upsertSourceBatch(
+        [{ ip: '41.0.0.4', port: 80, protocol: 'http' }],
+        nextName,
+        'TheSpeedX/socks4',
+        'batch-clean-4',
+        now,
+    );
+
+    const summary = h.db.purgeSocks4Data({
+        sourceName: 'TheSpeedX/socks4',
+        protocol: 'socks4',
+    });
+
+    assert.equal(summary.beforeSource, 2);
+    assert.equal(summary.beforeProtocol, 2);
+    assert.equal(summary.deleted, 3);
+    assert.equal(summary.afterSource, 0);
+    assert.equal(summary.afterProtocol, 0);
+
+    const remaining = h.db.getProxyList({ limit: 20 });
+    assert.equal(remaining.length, 1);
+    assert.equal(remaining[0].source, 'TheSpeedX/http');
+
+    cleanup(h);
+});
+
+test('purgeSocks4Data should support default source/protocol options', () => {
+    const h = createDb();
+    const now = new Date().toISOString();
+    let seq = 0;
+    const nextName = () => `默认清理-${++seq}`;
+
+    h.db.upsertSourceBatch(
+        [{ ip: '42.0.0.1', port: 1080, protocol: 'socks4' }],
+        nextName,
+        'TheSpeedX/socks4',
+        'batch-default-clean-1',
+        now,
+    );
+    h.db.upsertSourceBatch(
+        [{ ip: '42.0.0.2', port: 1080, protocol: 'socks4' }],
+        nextName,
+        'legacy-socks4-feed',
+        'batch-default-clean-2',
+        now,
+    );
+    h.db.upsertSourceBatch(
+        [{ ip: '42.0.0.3', port: 80, protocol: 'http' }],
+        nextName,
+        'TheSpeedX/http',
+        'batch-default-clean-3',
+        now,
+    );
+
+    const summary = h.db.purgeSocks4Data();
+    assert.equal(summary.sourceName, 'TheSpeedX/socks4');
+    assert.equal(summary.protocol, 'socks4');
+    assert.equal(summary.deleted, 2);
+    assert.equal(summary.afterSource, 0);
+    assert.equal(summary.afterProtocol, 0);
+
+    const remaining = h.db.getProxyList({ limit: 20 });
+    assert.equal(remaining.length, 1);
+    assert.equal(remaining[0].source, 'TheSpeedX/http');
+
+    cleanup(h);
+});
+
+test('getRecruitCampBoard should fallback invalid lifecycle counts to zero', () => {
+    const h = createDb();
+    const originalPrepare = h.db.db.prepare.bind(h.db.db);
+
+    h.db.db.prepare = (sql) => {
+        if (String(sql).includes('GROUP BY lifecycle')) {
+            return {
+                all() {
+                    return [
+                        { lifecycle: 'active', count: 'invalid' },
+                        { lifecycle: 'reserve', count: 2 },
+                        { lifecycle: 'unknown', count: 7 },
+                    ];
+                },
+            };
+        }
+        return originalPrepare(sql);
+    };
+
+    try {
+        const camp = h.db.getRecruitCampBoard();
+        assert.equal(camp.find((item) => item.lifecycle === 'active')?.count, 0);
+        assert.equal(camp.find((item) => item.lifecycle === 'reserve')?.count, 2);
+        assert.equal(camp.find((item) => item.lifecycle === 'candidate')?.count, 0);
+        assert.equal(camp.find((item) => item.lifecycle === 'retired')?.count, 0);
+    } finally {
+        h.db.db.prepare = originalPrepare;
+        cleanup(h);
+    }
+});
+
 test('value board API should sort by value and parse breakdown and honor fields', () => {
     const h = createDb();
     const now = new Date().toISOString();

--- a/apps/proxy-pool-service/src/engine.test.js
+++ b/apps/proxy-pool-service/src/engine.test.js
@@ -1410,6 +1410,35 @@ test('runBattleL2Cycle should process candidates and cover guard/error branches'
     cleanupDb(h);
 });
 
+test('runBattleL2Cycle should return early when there are no candidates', async () => {
+    const logger = createLogger();
+    const config = createConfig(path.join(os.tmpdir(), 'proxyhub-engine-l2-empty.db'));
+    config.battle.enabled = true;
+
+    let runTaskCalls = 0;
+    const db = {
+        listProxiesForBattleL2() {
+            return [];
+        },
+    };
+    const workerPool = {
+        async runTask() {
+            runTaskCalls += 1;
+            return { ok: true };
+        },
+        getStatus() {
+            return { workersTotal: 2, workersBusy: 0, queueSize: 0, runningTasks: 0, completedTasks: 0, failedTasks: 0, restartedWorkers: 0, workers: [] };
+        },
+    };
+
+    const engine = new ProxyHubEngine({ config, db, workerPool, logger });
+    engine.started = true;
+
+    await engine.runBattleL2Cycle();
+    assert.equal(runTaskCalls, 0);
+    assert.equal(engine.isBattleL2Running, false);
+});
+
 test('runBattle cycles should log outer-catch fallback reason when candidate listing throws', async () => {
     const logger = createLogger();
     const config = createConfig(path.join(os.tmpdir(), 'proxyhub-engine-battle-outer.db'));

--- a/apps/proxy-pool-service/src/server.js
+++ b/apps/proxy-pool-service/src/server.js
@@ -468,6 +468,22 @@ function createRuntime(options = {}) {
             try {
                 server = app.listen(config.service.port, config.service.host, () => {
                     server.off('error', onError);
+                    const socks4Feed = Array.isArray(config.source?.activeFeeds)
+                        ? config.source.activeFeeds.find((feed) => feed && feed.name === 'TheSpeedX/socks4')
+                        : null;
+                    if (socks4Feed && socks4Feed.enabled === false && typeof db.purgeSocks4Data === 'function') {
+                        const cleanupSummary = db.purgeSocks4Data({
+                            sourceName: socks4Feed.name,
+                            protocol: 'socks4',
+                        });
+                        logger.write({
+                            event: '数据清理',
+                            stage: '服务',
+                            result: `socks4 清理 ${cleanupSummary.deleted}`,
+                            action: '临时停用 TheSpeedX/socks4',
+                            details: cleanupSummary,
+                        });
+                    }
                     logger.write({
                         event: '自动恢复',
                         stage: '服务',

--- a/apps/proxy-pool-service/src/server.test.js
+++ b/apps/proxy-pool-service/src/server.test.js
@@ -30,7 +30,15 @@ function createConfig(port = 0) {
                 l2Fallback: [{ name: 'baidu', url: 'https://www.baidu.com' }],
             },
         },
-        source: { monosans: { name: 'monosans', url: 'https://x', enabled: true } },
+        source: {
+            activeProfile: 'speedx_bundle',
+            activeFeeds: [
+                { name: 'TheSpeedX/http', url: 'https://example.com/http.txt', enabled: true, defaultProtocol: 'http', sourceFormat: 'line' },
+                { name: 'TheSpeedX/socks4', url: 'https://example.com/socks4.txt', enabled: false, defaultProtocol: 'socks4', sourceFormat: 'line' },
+                { name: 'TheSpeedX/socks5', url: 'https://example.com/socks5.txt', enabled: true, defaultProtocol: 'socks5', sourceFormat: 'line' },
+            ],
+            monosans: { name: 'monosans', url: 'https://x', enabled: true },
+        },
         candidateControl: {
             max: 3000,
             gateOverride: false,
@@ -101,6 +109,7 @@ function createStubs() {
         engineStarted: false,
         engineStopped: false,
         engineStopCalls: 0,
+        socks4CleanupCalls: 0,
         rolloutState: {
             id: 1,
             mode: 'SAFE',
@@ -162,6 +171,18 @@ function createStubs() {
         },
         getRolloutSwitchEvents: (limit = 200) => state.rolloutEvents.slice(-limit).reverse(),
         getRuntimeLogs: () => [{ id: 5, event: '开始抓源' }],
+        purgeSocks4Data: () => {
+            state.socks4CleanupCalls += 1;
+            return {
+                sourceName: 'TheSpeedX/socks4',
+                protocol: 'socks4',
+                deleted: 2,
+                beforeSource: 1,
+                beforeProtocol: 1,
+                afterSource: 0,
+                afterProtocol: 0,
+            };
+        },
         close: () => {
             state.dbClosed = true;
         },
@@ -378,9 +399,37 @@ test('server runtime should expose all REST endpoints and shutdown cleanly', asy
     ssePool.body.cancel();
 
     await runtime.shutdown('TEST');
+    assert.equal(stubs.state.socks4CleanupCalls, 1);
     assert.equal(stubs.state.dbClosed, true);
     assert.equal(stubs.state.poolClosed, true);
     assert.equal(stubs.state.engineStopped, true);
+});
+
+test('startup socks4 cleanup should be skipped when socks4 feed is enabled', async () => {
+    const stubs = createStubs();
+    const config = createConfig(0);
+    const socks4Feed = config.source.activeFeeds.find((feed) => feed.name === 'TheSpeedX/socks4');
+    socks4Feed.enabled = true;
+
+    const { runtime } = await startRuntimeOnRandomPort({ ...stubs, config });
+    try {
+        assert.equal(stubs.state.socks4CleanupCalls, 0);
+    } finally {
+        await runtime.shutdown('TEST-SOCKS4-CLEANUP-SKIP');
+    }
+});
+
+test('startup socks4 cleanup should be skipped when activeFeeds is not an array', async () => {
+    const stubs = createStubs();
+    const config = createConfig(0);
+    config.source.activeFeeds = null;
+
+    const { runtime } = await startRuntimeOnRandomPort({ ...stubs, config });
+    try {
+        assert.equal(stubs.state.socks4CleanupCalls, 0);
+    } finally {
+        await runtime.shutdown('TEST-SOCKS4-CLEANUP-NON-ARRAY');
+    }
 });
 
 test('excludeRetired flag should be forwarded to admin stats endpoints', async () => {
@@ -532,6 +581,44 @@ test('candidate control GET should fallback when db method or config is missing'
         assert.deepEqual(body.candidateControl, {});
     } finally {
         await runtime.shutdown('TEST-CANDIDATE-CONTROL-GET-FALLBACK');
+    }
+});
+
+test('candidate control GET should fallback to candidate distribution count', async () => {
+    const stubs = createStubs();
+    stubs.db.getLifecycleDistribution = () => [
+        { lifecycle: 'active', count: 1 },
+        { lifecycle: 'candidate', count: '7' },
+    ];
+    stubs.db.getLifecycleCount = undefined;
+
+    const { runtime, baseUrl } = await startRuntimeOnRandomPort(stubs);
+    try {
+        const res = await fetch(baseUrl + '/v1/proxies/candidate-control');
+        assert.equal(res.status, 200);
+        const body = await res.json();
+        assert.equal(body.candidateCount, 7);
+        assert.equal(body.candidateControl.max, 3000);
+    } finally {
+        await runtime.shutdown('TEST-CANDIDATE-CONTROL-DISTRIBUTION-FALLBACK');
+    }
+});
+
+test('candidate control GET should prefer lifecycleCount when available', async () => {
+    const stubs = createStubs();
+    stubs.db.getLifecycleDistribution = () => [
+        { lifecycle: 'candidate', count: 99 },
+    ];
+    stubs.db.getLifecycleCount = () => 5;
+
+    const { runtime, baseUrl } = await startRuntimeOnRandomPort(stubs);
+    try {
+        const res = await fetch(baseUrl + '/v1/proxies/candidate-control');
+        assert.equal(res.status, 200);
+        const body = await res.json();
+        assert.equal(body.candidateCount, 5);
+    } finally {
+        await runtime.shutdown('TEST-CANDIDATE-CONTROL-LIFECYCLE-COUNT');
     }
 });
 


### PR DESCRIPTION
## Summary
- Temporarily disable `TheSpeedX/socks4` by default in `speedx_bundle` profile.
- Add a recover switch: set `PROXY_HUB_SPEEDX_SOCKS4_ENABLED=true` to re-enable this feed.
- Add DB cleanup API `purgeSocks4Data()` and run startup cleanup when socks4 feed is disabled.
- Add/extend tests for config, db, server startup cleanup path, candidate-control branches, and battle-L2 no-candidate early-return branch.

## Validation
- `npm run test:proxyhub:unit`
- `npm run test:proxyhub:coverage`

Closes #68