### PR TITLE
feat(proxyhub): unify service branch system and expose branch boards

### DIFF
--- a/apps/proxy-pool-service/src/config.js
+++ b/apps/proxy-pool-service/src/config.js
@@ -12,6 +12,19 @@ function deepClone(value) {
     return JSON.parse(JSON.stringify(value));
 }
 
+// 0271_parseJsonArrayEnv_解析JSON数组环境变量逻辑
+function parseJsonArrayEnv(value, fallback) {
+    if (value == null || String(value).trim() === '') {
+        return deepClone(fallback);
+    }
+    try {
+        const parsed = JSON.parse(String(value));
+        return Array.isArray(parsed) ? parsed : deepClone(fallback);
+    } catch {
+        return deepClone(fallback);
+    }
+}
+
 const legacyRanks = [
     { rank: '新兵', minHours: 0, minPoints: 0, minSamples: 0 },
     { rank: '列兵', minHours: 12, minPoints: 80, minSamples: 20 },
@@ -182,8 +195,9 @@ const policyProfiles = {
     },
 };
 
-const activeProfile = ['production', 'soak'].includes(String(process.env.PROXY_HUB_POLICY_PROFILE || '').toLowerCase())
-    ? String(process.env.PROXY_HUB_POLICY_PROFILE || '').toLowerCase()
+const policyProfileRaw = String(process.env.PROXY_HUB_POLICY_PROFILE || '').toLowerCase();
+const activeProfile = ['production', 'soak'].includes(policyProfileRaw)
+    ? policyProfileRaw
     : 'production';
 
 const battleL1LifecycleQuotaByProfile = {
@@ -227,6 +241,64 @@ const lifecycleQuotaFromEnv = parseLifecycleQuota(
 const resolvedLifecycleQuota = hasLifecycleQuotaEnv
     ? lifecycleQuotaFromEnv
     : (hasCandidateQuotaEnv ? undefined : defaultLifecycleQuota);
+
+const defaultBranchingRules = [
+    {
+        id: 'l2_promote_navy',
+        priority: 10,
+        stage: 'l2',
+        outcomes: ['success'],
+        from: ['陆军'],
+        to: '海军',
+        failStreakOp: 'reset',
+        eventType: 'branch_transfer',
+    },
+    {
+        id: 'l2_reset_navy_streak',
+        priority: 20,
+        stage: 'l2',
+        outcomes: ['success'],
+        from: ['海军'],
+        failStreakOp: 'reset',
+        eventType: 'branch_streak_reset',
+    },
+    {
+        id: 'l2_fail_navy_fallback',
+        priority: 30,
+        stage: 'l2',
+        outcomes: ['blocked', 'timeout', 'network_error', 'invalid_feedback'],
+        from: ['海军'],
+        failStreakOp: 'increment',
+        fallbackAt: 3,
+        fallbackTo: '陆军',
+        eventType: 'branch_fallback',
+    },
+    {
+        id: 'l3_promote_seal',
+        priority: 40,
+        stage: 'l3',
+        outcomes: ['success'],
+        from: ['陆军', '海军', '海豹突击队'],
+        to: '海豹突击队',
+        failStreakOp: 'reset',
+        eventType: 'branch_transfer',
+    },
+    {
+        id: 'l3_fail_seal_fallback',
+        priority: 50,
+        stage: 'l3',
+        outcomes: ['blocked', 'timeout', 'network_error', 'invalid_feedback'],
+        from: ['海豹突击队'],
+        failStreakOp: 'increment',
+        fallbackAt: 3,
+        fallbackTo: '陆军',
+        eventType: 'branch_fallback',
+    },
+];
+const resolvedBranchingRules = parseJsonArrayEnv(
+    process.env.PROXY_HUB_BRANCHING_RULES_JSON,
+    defaultBranchingRules,
+);
 
 const sourceProfiles = {
     speedx_bundle: {
@@ -425,6 +497,13 @@ module.exports = {
     validation: {
         allowedProtocols: ['http', 'https', 'socks4', 'socks5'],
         maxTimeoutMs: 2_500,
+    },
+    branching: {
+        enabled: toBool(process.env.PROXY_HUB_BRANCHING_ENABLED, true),
+        fieldName: 'service_branch',
+        failStreakField: 'branch_fail_streak',
+        defaultBranch: String(process.env.PROXY_HUB_BRANCHING_DEFAULT || '陆军'),
+        rules: deepClone(resolvedBranchingRules),
     },
     policyProfiles: deepClone(policyProfiles),
     policy: deepClone(policyProfiles[activeProfile]),

--- a/apps/proxy-pool-service/src/config.test.js
+++ b/apps/proxy-pool-service/src/config.test.js
@@ -34,6 +34,9 @@ function loadConfigWithEnv(overrides = {}) {
         'PROXY_HUB_SOURCE_FORMAT',
         'PROXY_HUB_SOURCE_PROFILE',
         'PROXY_HUB_SPEEDX_SOCKS4_ENABLED',
+        'PROXY_HUB_BRANCHING_ENABLED',
+        'PROXY_HUB_BRANCHING_DEFAULT',
+        'PROXY_HUB_BRANCHING_RULES_JSON',
         'PROXY_HUB_DB_PATH',
         ...Object.keys(overrides),
     ]);
@@ -78,6 +81,9 @@ test('config should expose required default values', { concurrency: false }, () 
     assert.equal(config.source.profiles.monosans_archive.enabled, false);
     assert.equal(config.storage.dbPath.includes('proxyhub-speedx-bundle.db'), true);
     assert.equal(config.validation.allowedProtocols.includes('socks4'), true);
+    assert.equal(config.branching.defaultBranch, '陆军');
+    assert.equal(Array.isArray(config.branching.rules), true);
+    assert.equal(config.branching.rules.length >= 4, true);
     assert.equal(config.battle.enabled, true);
     assert.equal(config.battle.l1SyncMs, 300000);
     assert.equal(config.battle.l2SyncMs, 1800000);
@@ -145,6 +151,46 @@ test('config should allow re-enable speedx socks4 feed by env switch', { concurr
 
     assert.equal(config.source.activeProfile, 'speedx_bundle');
     assert.equal(config.source.activeFeeds.some((feed) => feed.name === 'TheSpeedX/socks4' && feed.enabled === true), true);
+});
+
+test('config should support branching env overrides', { concurrency: false }, () => {
+    const config = loadConfigWithEnv({
+        PROXY_HUB_BRANCHING_ENABLED: 'false',
+        PROXY_HUB_BRANCHING_DEFAULT: '空军',
+        PROXY_HUB_BRANCHING_RULES_JSON: JSON.stringify([
+            {
+                id: 'custom',
+                priority: 1,
+                stage: 'l2',
+                outcomes: ['success'],
+                from: ['空军'],
+                to: '太空军',
+            },
+        ]),
+    });
+
+    assert.equal(config.branching.enabled, false);
+    assert.equal(config.branching.defaultBranch, '空军');
+    assert.equal(config.branching.rules.length, 1);
+    assert.equal(config.branching.rules[0].id, 'custom');
+});
+
+test('config should fallback branching rules when env json is invalid', { concurrency: false }, () => {
+    const config = loadConfigWithEnv({
+        PROXY_HUB_BRANCHING_RULES_JSON: '{bad-json',
+    });
+
+    assert.equal(Array.isArray(config.branching.rules), true);
+    assert.equal(config.branching.rules.length >= 4, true);
+});
+
+test('config should fallback branching rules when env json is not an array', { concurrency: false }, () => {
+    const config = loadConfigWithEnv({
+        PROXY_HUB_BRANCHING_RULES_JSON: '{"id":"not-array"}',
+    });
+
+    assert.equal(Array.isArray(config.branching.rules), true);
+    assert.equal(config.branching.rules.length >= 4, true);
 });
 
 test('config should prioritize explicit PROXY_HUB_DB_PATH over profile db mapping', { concurrency: false }, () => {

--- a/apps/proxy-pool-service/src/db.js
+++ b/apps/proxy-pool-service/src/db.js
@@ -64,6 +64,8 @@ class ProxyHubDb {
                 display_name TEXT NOT NULL UNIQUE,
                 lifecycle TEXT NOT NULL DEFAULT 'candidate',
                 rank TEXT NOT NULL DEFAULT '新兵',
+                service_branch TEXT NOT NULL DEFAULT '陆军',
+                branch_fail_streak INTEGER NOT NULL DEFAULT 0,
                 service_hours REAL NOT NULL DEFAULT 0,
                 rank_service_hours REAL NOT NULL DEFAULT 0,
                 combat_points INTEGER NOT NULL DEFAULT 0,
@@ -313,6 +315,8 @@ class ProxyHubDb {
             { name: 'last_l1_success_at', sql: 'TEXT' },
             { name: 'backoff_until', sql: 'TEXT' },
             { name: 'backoff_reason', sql: 'TEXT' },
+            { name: 'service_branch', sql: "TEXT NOT NULL DEFAULT '陆军'" },
+            { name: 'branch_fail_streak', sql: 'INTEGER NOT NULL DEFAULT 0' },
         ];
 
         for (const column of requiredColumns) {
@@ -1066,7 +1070,7 @@ class ProxyHubDb {
     }
 
     // 0187_getProxyList_获取代理列表逻辑
-    getProxyList({ limit = 200, rank, lifecycle, excludeRetired = false } = {}) {
+    getProxyList({ limit = 200, rank, lifecycle, serviceBranch, excludeRetired = false } = {}) {
         const clauses = [];
         const params = {};
 
@@ -1078,6 +1082,10 @@ class ProxyHubDb {
             clauses.push('lifecycle = @lifecycle');
             params.lifecycle = lifecycle;
         }
+        if (serviceBranch) {
+            clauses.push('service_branch = @service_branch');
+            params.service_branch = serviceBranch;
+        }
         if (excludeRetired) {
             clauses.push("lifecycle != 'retired'");
         }
@@ -1085,6 +1093,7 @@ class ProxyHubDb {
         const where = clauses.length ? `WHERE ${clauses.join(' AND ')}` : '';
         return this.db.prepare(`
             SELECT id, display_name, ip, port, protocol, source, lifecycle, rank,
+                service_branch, branch_fail_streak,
                 service_hours, rank_service_hours, combat_points, health_score, discipline_score,
                 success_count, block_count, timeout_count, network_error_count,
                 total_samples, retired_type, is_applied, updated_at, last_checked_at,
@@ -1129,9 +1138,14 @@ class ProxyHubDb {
         const clauses = [];
         const params = { limit: safeLimit };
         const excludeRetired = options.excludeRetired === true;
+        const serviceBranch = options.serviceBranch ? String(options.serviceBranch) : undefined;
         if (lifecycle) {
             clauses.push('lifecycle = @lifecycle');
             params.lifecycle = String(lifecycle);
+        }
+        if (serviceBranch) {
+            clauses.push('service_branch = @service_branch');
+            params.service_branch = serviceBranch;
         }
         if (excludeRetired) {
             clauses.push("lifecycle != 'retired'");
@@ -1140,6 +1154,7 @@ class ProxyHubDb {
         const where = clauses.length ? `WHERE ${clauses.join(' AND ')}` : '';
         const rows = this.db.prepare(`
             SELECT id, display_name, ip, port, protocol, source, lifecycle, rank,
+                service_branch,
                 ip_value_score, ip_value_breakdown_json,
                 combat_points, health_score, discipline_score,
                 success_count, total_samples, battle_success_count, battle_fail_count,
@@ -1394,6 +1409,19 @@ class ProxyHubDb {
             FROM proxies
             ${where}
             GROUP BY lifecycle
+        `).all();
+    }
+
+    // 0272_getServiceBranchDistribution_获取编制分布逻辑
+    getServiceBranchDistribution(options = {}) {
+        const excludeRetired = options.excludeRetired === true;
+        const where = excludeRetired ? "WHERE lifecycle != 'retired'" : '';
+        return this.db.prepare(`
+            SELECT service_branch, COUNT(*) AS count
+            FROM proxies
+            ${where}
+            GROUP BY service_branch
+            ORDER BY count DESC, service_branch ASC
         `).all();
     }
 

--- a/apps/proxy-pool-service/src/db.test.js
+++ b/apps/proxy-pool-service/src/db.test.js
@@ -260,15 +260,34 @@ test('query list APIs should support filters and distributions', () => {
     assert.equal(Object.prototype.hasOwnProperty.call(all[0], 'battle_success_count'), true);
     assert.equal(Object.prototype.hasOwnProperty.call(all[0], 'last_validation_ok'), true);
     assert.equal(Object.prototype.hasOwnProperty.call(all[0], 'ip_value_score'), true);
+    assert.equal(Object.prototype.hasOwnProperty.call(all[0], 'service_branch'), true);
+    assert.equal(Object.prototype.hasOwnProperty.call(all[0], 'branch_fail_streak'), true);
+    assert.equal(all[0].service_branch, '陆军');
+    assert.equal(all[0].branch_fail_streak, 0);
 
-    h.db.updateProxyById(all[0].id, { rank: '士官', lifecycle: 'active', updated_at: now });
+    h.db.updateProxyById(all[0].id, {
+        rank: '士官',
+        lifecycle: 'active',
+        service_branch: '海军',
+        branch_fail_streak: 2,
+        ip_value_score: 88,
+        updated_at: now,
+    });
 
     const filtered = h.db.getProxyList({ limit: 10, rank: '士官', lifecycle: 'active' });
     assert.equal(filtered.length, 1);
+    const branchFiltered = h.db.getProxyList({ limit: 10, serviceBranch: '海军' });
+    assert.equal(branchFiltered.length, 1);
+    assert.equal(branchFiltered[0].service_branch, '海军');
+    const valueBoardByBranch = h.db.getValueBoard(10, undefined, { serviceBranch: '海军' });
+    assert.equal(valueBoardByBranch.length, 1);
+    assert.equal(valueBoardByBranch[0].service_branch, '海军');
 
     assert.equal(h.db.getSourceDistribution().length, 1);
     assert.equal(h.db.getLifecycleDistribution().length >= 1, true);
     assert.equal(h.db.getRankBoard().length >= 1, true);
+    assert.equal(h.db.getServiceBranchDistribution().some((item) => item.service_branch === '海军'), true);
+    assert.equal(h.db.getServiceBranchDistribution({ excludeRetired: true }).some((item) => item.service_branch === '海军'), true);
 
     cleanup(h);
 });

--- a/apps/proxy-pool-service/src/engine.js
+++ b/apps/proxy-pool-service/src/engine.js
@@ -195,6 +195,217 @@ function resolveSourceFeeds(config = {}) {
     return [];
 }
 
+const DEFAULT_BRANCH_FAIL_OUTCOMES = ['blocked', 'timeout', 'network_error', 'invalid_feedback'];
+const DEFAULT_BRANCHING_RULES = [
+    {
+        id: 'l2_promote_navy',
+        priority: 10,
+        stage: 'l2',
+        outcomes: ['success'],
+        from: ['陆军'],
+        to: '海军',
+        failStreakOp: 'reset',
+        eventType: 'branch_transfer',
+    },
+    {
+        id: 'l2_reset_navy_streak',
+        priority: 20,
+        stage: 'l2',
+        outcomes: ['success'],
+        from: ['海军'],
+        failStreakOp: 'reset',
+        eventType: 'branch_streak_reset',
+    },
+    {
+        id: 'l2_fail_navy_fallback',
+        priority: 30,
+        stage: 'l2',
+        outcomes: DEFAULT_BRANCH_FAIL_OUTCOMES,
+        from: ['海军'],
+        failStreakOp: 'increment',
+        fallbackAt: 3,
+        fallbackTo: '陆军',
+        eventType: 'branch_fallback',
+    },
+    {
+        id: 'l3_promote_seal',
+        priority: 40,
+        stage: 'l3',
+        outcomes: ['success'],
+        from: ['陆军', '海军', '海豹突击队'],
+        to: '海豹突击队',
+        failStreakOp: 'reset',
+        eventType: 'branch_transfer',
+    },
+    {
+        id: 'l3_fail_seal_fallback',
+        priority: 50,
+        stage: 'l3',
+        outcomes: DEFAULT_BRANCH_FAIL_OUTCOMES,
+        from: ['海豹突击队'],
+        failStreakOp: 'increment',
+        fallbackAt: 3,
+        fallbackTo: '陆军',
+        eventType: 'branch_fallback',
+    },
+];
+
+// 0273_normalizeBranchRuleList_规范化编制规则列表逻辑
+function normalizeBranchRuleList(value, fallback = []) {
+    if (!Array.isArray(value)) {
+        return [...fallback];
+    }
+    const normalized = value
+        .map((item) => String(item || '').trim())
+        .filter((item) => item.length > 0);
+    return normalized.length > 0 ? normalized : [...fallback];
+}
+
+// 0274_readBranchingConfig_读取编制配置逻辑
+function readBranchingConfig(config = {}) {
+    const raw = config.branching || {};
+    const fieldName = String(raw.fieldName || 'service_branch').trim() || 'service_branch';
+    const failStreakField = String(raw.failStreakField || 'branch_fail_streak').trim() || 'branch_fail_streak';
+    const defaultBranch = String(raw.defaultBranch || '陆军').trim() || '陆军';
+    const rawRules = Array.isArray(raw.rules) && raw.rules.length > 0
+        ? raw.rules
+        : DEFAULT_BRANCHING_RULES;
+
+    const rules = rawRules.map((rule, index) => {
+        const normalized = rule && typeof rule === 'object' ? rule : {};
+        const stageList = normalizeBranchRuleList(
+            normalized.stages || [normalized.stage || '*'],
+            ['*'],
+        ).map((item) => item.toLowerCase());
+        const outcomeList = normalizeBranchRuleList(
+            normalized.outcomes || [normalized.outcome || '*'],
+            ['*'],
+        ).map((item) => item.toLowerCase());
+        const fromList = normalizeBranchRuleList(
+            normalized.from || normalized.fromBranches || ['*'],
+            ['*'],
+        );
+        const failStreakOp = ['none', 'reset', 'increment', 'set'].includes(String(normalized.failStreakOp || 'none'))
+            ? String(normalized.failStreakOp || 'none')
+            : 'none';
+        const fallbackAt = Number(normalized.fallbackAt);
+        const failStreakValue = Number(normalized.failStreakValue);
+        return {
+            id: String(normalized.id || `branch_rule_${index + 1}`),
+            priority: Number(normalized.priority) || (index + 1) * 10,
+            stages: stageList,
+            outcomes: outcomeList,
+            from: fromList,
+            to: normalized.to == null ? null : String(normalized.to),
+            failStreakOp,
+            failStreakValue: Number.isFinite(failStreakValue) ? Math.max(0, Math.round(failStreakValue)) : 0,
+            fallbackAt: Number.isFinite(fallbackAt) ? Math.max(1, Math.round(fallbackAt)) : null,
+            fallbackTo: normalized.fallbackTo == null ? null : String(normalized.fallbackTo),
+            eventType: String(normalized.eventType || 'branch_transition'),
+        };
+    }).sort((a, b) => a.priority - b.priority);
+
+    return {
+        enabled: raw.enabled !== false,
+        fieldName,
+        failStreakField,
+        defaultBranch,
+        rules,
+    };
+}
+
+// 0275_resolveBranchingTransition_解析编制流转逻辑
+function resolveBranchingTransition({
+    proxy = {},
+    stage = 'l2',
+    outcome = 'success',
+    config = {},
+} = {}) {
+    const policy = readBranchingConfig(config);
+    if (!policy.enabled) {
+        return { updates: {}, events: [] };
+    }
+
+    const stageText = String(stage || '').toLowerCase();
+    const outcomeText = String(outcome || '').toLowerCase();
+    const currentBranchRaw = proxy?.[policy.fieldName];
+    const currentBranch = String(currentBranchRaw == null ? policy.defaultBranch : currentBranchRaw) || policy.defaultBranch;
+    const currentStreak = Math.max(0, Number(proxy?.[policy.failStreakField]) || 0);
+
+    const matchedRule = policy.rules.find((rule) => {
+        const stageMatch = rule.stages.includes('*') || rule.stages.includes(stageText);
+        const outcomeMatch = rule.outcomes.includes('*') || rule.outcomes.includes(outcomeText);
+        const fromMatch = rule.from.includes('*') || rule.from.includes(currentBranch);
+        return stageMatch && outcomeMatch && fromMatch;
+    });
+    if (!matchedRule) {
+        return { updates: {}, events: [] };
+    }
+
+    let nextBranch = currentBranch;
+    let nextStreak = currentStreak;
+    if (matchedRule.to) {
+        nextBranch = matchedRule.to;
+    }
+
+    if (matchedRule.failStreakOp === 'reset') {
+        nextStreak = 0;
+    } else if (matchedRule.failStreakOp === 'increment') {
+        nextStreak = currentStreak + 1;
+    } else if (matchedRule.failStreakOp === 'set') {
+        nextStreak = matchedRule.failStreakValue;
+    }
+
+    let fallbackApplied = false;
+    if (matchedRule.fallbackAt != null && nextStreak >= matchedRule.fallbackAt) {
+        nextBranch = matchedRule.fallbackTo || policy.defaultBranch;
+        nextStreak = 0;
+        fallbackApplied = true;
+    }
+
+    const updates = {};
+    if (nextBranch !== currentBranch) {
+        updates[policy.fieldName] = nextBranch;
+    }
+    if (nextStreak !== currentStreak) {
+        updates[policy.failStreakField] = nextStreak;
+    }
+
+    if (Object.keys(updates).length === 0) {
+        return { updates, events: [] };
+    }
+
+    const details = {
+        ruleId: matchedRule.id,
+        stage: stageText,
+        outcome: outcomeText,
+        branchBefore: currentBranch,
+        branchAfter: nextBranch,
+        failStreakBefore: currentStreak,
+        failStreakAfter: nextStreak,
+        fallbackApplied,
+    };
+    const events = [];
+
+    if (nextBranch !== currentBranch) {
+        events.push({
+            event_type: fallbackApplied ? 'branch_fallback' : matchedRule.eventType,
+            message: `编制流转：${currentBranch} -> ${nextBranch}`,
+            details,
+        });
+    } else if (nextStreak !== currentStreak) {
+        events.push({
+            event_type: matchedRule.failStreakOp === 'reset' ? 'branch_streak_reset' : 'branch_streak',
+            message: matchedRule.failStreakOp === 'reset'
+                ? `编制计数清零：${nextBranch}`
+                : `编制连续失败：${nextBranch} (${nextStreak})`,
+            details,
+        });
+    }
+
+    return { updates, events };
+}
+
 class ProxyHubEngine extends EventEmitter {
     // 0027_constructor_初始化实例逻辑
     constructor({ config, db, workerPool, logger, now }) {
@@ -558,10 +769,17 @@ class ProxyHubEngine extends EventEmitter {
             config: this.config,
             stage: combatStage,
         });
+        const branchTransition = resolveBranchingTransition({
+            proxy: currentProxy,
+            stage: combatStage,
+            outcome,
+            config: this.config,
+        });
 
         this.db.updateProxyById(proxyId, {
             ...combat.updates,
             ...extraUpdates,
+            ...branchTransition.updates,
             updated_at: nowIso,
         });
 
@@ -613,6 +831,29 @@ class ProxyHubEngine extends EventEmitter {
                     stage: combatStage,
                     outcome,
                 },
+            });
+        }
+
+        for (const event of branchTransition.events) {
+            this.db.insertProxyEvent({
+                timestamp: nowIso,
+                proxy_id: proxyId,
+                display_name: updatedProxy.display_name,
+                event_type: event.event_type,
+                level: EVENT_LEVEL.INFO,
+                message: event.message,
+                details: event.details,
+            });
+
+            this.logger.write({
+                event: '编制流转',
+                proxyName: updatedProxy.display_name,
+                ipSource: sourceName,
+                stage: '编制',
+                result: event.message,
+                reason: `${event.details.branchBefore} -> ${event.details.branchAfter}`,
+                action: '按规则自动调整',
+                details: event.details,
             });
         }
 
@@ -1135,6 +1376,8 @@ module.exports = {
     readFailureBackoff,
     resolveFailureBackoff,
     resolveSourceFeeds,
+    readBranchingConfig,
+    resolveBranchingTransition,
     ProxyHubEngine,
 };
 

--- a/apps/proxy-pool-service/src/engine.test.js
+++ b/apps/proxy-pool-service/src/engine.test.js
@@ -16,6 +16,8 @@ const {
     readFailureBackoff,
     resolveFailureBackoff,
     resolveSourceFeeds,
+    readBranchingConfig,
+    resolveBranchingTransition,
     ProxyHubEngine,
 } = require('./engine');
 
@@ -194,6 +196,159 @@ test('engine utility functions should cover helper branches', async () => {
         multiplier: 1.8,
         maxMs: 21600000,
     });
+    const branchPolicy = readBranchingConfig({});
+    assert.equal(branchPolicy.enabled, true);
+    assert.equal(branchPolicy.defaultBranch, '陆军');
+    assert.equal(Array.isArray(branchPolicy.rules), true);
+    assert.equal(branchPolicy.rules.length >= 4, true);
+    const disabledPolicy = readBranchingConfig({ branching: { enabled: false } });
+    assert.equal(disabledPolicy.enabled, false);
+    const normalizedPolicy = readBranchingConfig({
+        branching: {
+            rules: [{
+                id: 'norm',
+                stage: 'l9',
+                outcomes: [],
+                from: [],
+                failStreakOp: 'bad-op',
+                fallbackAt: 'bad',
+                failStreakValue: 'bad',
+            }],
+        },
+    });
+    assert.equal(normalizedPolicy.rules[0].failStreakOp, 'none');
+    assert.equal(normalizedPolicy.rules[0].fallbackAt, null);
+    assert.equal(normalizedPolicy.rules[0].failStreakValue, 0);
+    const generatedIdPolicy = readBranchingConfig({
+        branching: {
+            rules: [{
+                stage: 'l2',
+                outcomes: ['success'],
+                from: ['陆军'],
+            }],
+        },
+    });
+    assert.equal(generatedIdPolicy.rules[0].id, 'branch_rule_1');
+    const stringRulePolicy = readBranchingConfig({
+        branching: {
+            rules: [{
+                id: 'string-rule',
+                stages: 'l2',
+                outcomes: 'success',
+                from: '陆军',
+            }],
+        },
+    });
+    assert.deepEqual(stringRulePolicy.rules[0].stages, ['*']);
+    assert.deepEqual(stringRulePolicy.rules[0].outcomes, ['*']);
+    assert.deepEqual(stringRulePolicy.rules[0].from, ['*']);
+    const branchPromote = resolveBranchingTransition({
+        proxy: { service_branch: '陆军', branch_fail_streak: 0 },
+        stage: 'l2',
+        outcome: 'success',
+        config: {},
+    });
+    assert.equal(branchPromote.updates.service_branch, '海军');
+    assert.equal(branchPromote.updates.branch_fail_streak, undefined);
+    assert.equal(branchPromote.events[0].event_type, 'branch_transfer');
+    const branchDisabled = resolveBranchingTransition({
+        proxy: { service_branch: '陆军', branch_fail_streak: 0 },
+        stage: 'l2',
+        outcome: 'success',
+        config: { branching: { enabled: false } },
+    });
+    assert.deepEqual(branchDisabled, { updates: {}, events: [] });
+    const branchNoMatch = resolveBranchingTransition({
+        proxy: { service_branch: '陆军', branch_fail_streak: 0 },
+        stage: 'l9',
+        outcome: 'blocked',
+        config: {},
+    });
+    assert.deepEqual(branchNoMatch, { updates: {}, events: [] });
+    const branchSet = resolveBranchingTransition({
+        proxy: { service_branch: '空军', branch_fail_streak: 1 },
+        stage: 'l9',
+        outcome: 'success',
+        config: {
+            branching: {
+                rules: [{
+                    id: 'set-streak',
+                    stage: 'l9',
+                    outcomes: ['success'],
+                    from: ['空军'],
+                    failStreakOp: 'set',
+                    failStreakValue: 4,
+                }],
+            },
+        },
+    });
+    assert.equal(branchSet.updates.branch_fail_streak, 4);
+    assert.equal(branchSet.events[0].event_type, 'branch_streak');
+    const branchNoop = resolveBranchingTransition({
+        proxy: { service_branch: '空军', branch_fail_streak: 4 },
+        stage: 'l9',
+        outcome: 'success',
+        config: {
+            branching: {
+                rules: [{
+                    id: 'set-streak-noop',
+                    stage: 'l9',
+                    outcomes: ['success'],
+                    from: ['空军'],
+                    failStreakOp: 'set',
+                    failStreakValue: 4,
+                }],
+            },
+        },
+    });
+    assert.deepEqual(branchNoop, { updates: {}, events: [] });
+    const branchResetOnly = resolveBranchingTransition({
+        proxy: { service_branch: '海军', branch_fail_streak: 2 },
+        stage: 'l2',
+        outcome: 'success',
+        config: {},
+    });
+    assert.equal(branchResetOnly.updates.branch_fail_streak, 0);
+    assert.equal(branchResetOnly.events[0].event_type, 'branch_streak_reset');
+    assert.equal(branchResetOnly.events[0].message.includes('编制计数清零'), true);
+    const branchFallbackDefault = resolveBranchingTransition({
+        proxy: { service_branch: '海军', branch_fail_streak: 0 },
+        stage: 'l9',
+        outcome: 'blocked',
+        config: {
+            branching: {
+                defaultBranch: '预备役',
+                rules: [{
+                    id: 'fallback-default',
+                    stage: 'l9',
+                    outcomes: ['blocked'],
+                    from: ['海军'],
+                    failStreakOp: 'increment',
+                    fallbackAt: 1,
+                }],
+            },
+        },
+    });
+    assert.equal(branchFallbackDefault.updates.service_branch, '预备役');
+    assert.equal(branchFallbackDefault.events[0].event_type, 'branch_fallback');
+    const branchEmptyInputs = resolveBranchingTransition({
+        proxy: { service_branch: '', branch_fail_streak: 0 },
+        stage: '',
+        outcome: '',
+        config: {
+            branching: {
+                defaultBranch: '陆军',
+                rules: [{
+                    id: 'empty-inputs',
+                    stages: ['*'],
+                    outcomes: ['*'],
+                    from: ['陆军'],
+                    to: '海军',
+                }],
+            },
+        },
+    });
+    assert.equal(branchEmptyInputs.updates.service_branch, '海军');
     assert.deepEqual(resolveSourceFeeds(), []);
     assert.deepEqual(resolveSourceFeeds({ source: {} }), []);
     assert.equal(resolveSourceFeeds({
@@ -423,6 +578,40 @@ test('runSourceCycle should skip when not started or source disabled', async () 
 
     assert.equal(logger.entries.length, 0);
     cleanupDb(h);
+});
+
+test('runValidationCycle should use proxy source first and fallback to sourceName', async () => {
+    const config = createConfig(path.join(os.tmpdir(), 'proxyhub-engine-validation-source.db'));
+    const logger = createLogger();
+    const candidates = [
+        { id: 1, source: 'proxy-source-a' },
+        { id: 2 },
+    ];
+    const db = {
+        listProxiesForValidation() {
+            return candidates;
+        },
+    };
+    const workerPool = {
+        async runTask() {
+            return { ok: true };
+        },
+        getStatus() {
+            return { workersTotal: 1, workersBusy: 0, queueSize: 0, runningTasks: 0, completedTasks: 0, failedTasks: 0, restartedWorkers: 0, workers: [] };
+        },
+    };
+    const engine = new ProxyHubEngine({ config, db, workerPool, logger });
+    const seenSources = [];
+    engine.processProxy = async (proxy, source) => {
+        seenSources.push(`${proxy.id}:${source}`);
+    };
+
+    await engine.runValidationCycle('fallback-source');
+
+    assert.deepEqual(seenSources, [
+        '1:proxy-source-a',
+        '2:fallback-source',
+    ]);
 });
 
 test('runSourceCycle and processProxy should handle success path', async () => {
@@ -1212,6 +1401,113 @@ test('applyCombatOutcome should return early when proxy does not exist', async (
         stage: '评分',
     });
     assert.equal(logger.entries.length, 0);
+});
+
+test('resolveBranchingTransition should support custom rule extension', () => {
+    const transition = resolveBranchingTransition({
+        proxy: {
+            service_branch: '空军',
+            branch_fail_streak: 0,
+        },
+        stage: 'l9',
+        outcome: 'success',
+        config: {
+            branching: {
+                rules: [
+                    {
+                        id: 'custom-l9',
+                        priority: 1,
+                        stage: 'l9',
+                        outcomes: ['success'],
+                        from: ['空军'],
+                        to: '天军',
+                        failStreakOp: 'reset',
+                    },
+                ],
+            },
+        },
+    });
+
+    assert.equal(transition.updates.service_branch, '天军');
+    assert.equal(transition.updates.branch_fail_streak, undefined);
+    assert.equal(transition.events.length, 1);
+    assert.equal(transition.events[0].event_type, 'branch_transition');
+});
+
+test('applyCombatOutcome should apply l2 branch transfer and fallback rules', async () => {
+    const h = createDbHandle();
+    const logger = createLogger();
+    const now = '2026-03-14T10:00:00.000Z';
+    h.db.upsertSourceBatch(
+        [{ ip: '10.0.0.91', port: 8080, protocol: 'http' }],
+        () => '编制-流转-91',
+        'src',
+        'batch',
+        now,
+    );
+    const proxy = h.db.getProxyList({ limit: 1 })[0];
+
+    const workerPool = {
+        async runTask() {
+            return { ok: true };
+        },
+        getStatus() {
+            return { workersTotal: 1, workersBusy: 0, queueSize: 0, runningTasks: 0, completedTasks: 0, failedTasks: 0, restartedWorkers: 0, workers: [] };
+        },
+    };
+    const engine = new ProxyHubEngine({ config: h.config, db: h.db, workerPool, logger });
+
+    await engine.applyCombatOutcome({
+        proxyId: proxy.id,
+        sourceName: 'battle-l2',
+        outcome: 'success',
+        latencyMs: 20,
+        nowIso: '2026-03-14T10:00:00.000Z',
+        stage: '评分(L2)',
+        combatStage: 'l2',
+    });
+    const promoted = h.db.getProxyById(proxy.id);
+    assert.equal(promoted.service_branch, '海军');
+    assert.equal(promoted.branch_fail_streak, 0);
+
+    await engine.applyCombatOutcome({
+        proxyId: proxy.id,
+        sourceName: 'battle-l2',
+        outcome: 'network_error',
+        latencyMs: 0,
+        nowIso: '2026-03-14T10:10:00.000Z',
+        stage: '评分(L2)',
+        combatStage: 'l2',
+    });
+    await engine.applyCombatOutcome({
+        proxyId: proxy.id,
+        sourceName: 'battle-l2',
+        outcome: 'network_error',
+        latencyMs: 0,
+        nowIso: '2026-03-14T10:20:00.000Z',
+        stage: '评分(L2)',
+        combatStage: 'l2',
+    });
+    const beforeFallback = h.db.getProxyById(proxy.id);
+    assert.equal(beforeFallback.service_branch, '海军');
+    assert.equal(beforeFallback.branch_fail_streak, 2);
+
+    await engine.applyCombatOutcome({
+        proxyId: proxy.id,
+        sourceName: 'battle-l2',
+        outcome: 'network_error',
+        latencyMs: 0,
+        nowIso: '2026-03-14T10:30:00.000Z',
+        stage: '评分(L2)',
+        combatStage: 'l2',
+    });
+    const fallenBack = h.db.getProxyById(proxy.id);
+    assert.equal(fallenBack.service_branch, '陆军');
+    assert.equal(fallenBack.branch_fail_streak, 0);
+    assert.equal(h.db.getEvents(50).some((item) => item.event_type === 'branch_fallback'), true);
+    assert.equal(logger.entries.some((item) => item.event === '编制流转'), true);
+
+    cleanupDb(h);
 });
 
 test('runBattleL1Cycle should cover guard and error branches', async () => {

--- a/apps/proxy-pool-service/src/server.js
+++ b/apps/proxy-pool-service/src/server.js
@@ -137,10 +137,11 @@ function createRuntime(options = {}) {
         const limit = normalizeLimit(req.query.limit, 200, 1, 500);
         const rank = req.query.rank ? String(req.query.rank) : undefined;
         const lifecycle = req.query.lifecycle ? String(req.query.lifecycle) : undefined;
+        const serviceBranch = req.query.serviceBranch ? String(req.query.serviceBranch) : undefined;
         const excludeRetired = normalizeBooleanFlag(req.query.excludeRetired, false);
 
         res.json({
-            items: db.getProxyList({ limit, rank, lifecycle, excludeRetired }),
+            items: db.getProxyList({ limit, rank, lifecycle, serviceBranch, excludeRetired }),
         });
     });
 
@@ -161,9 +162,10 @@ function createRuntime(options = {}) {
     app.get('/v1/proxies/value-board', (req, res) => {
         const limit = normalizeLimit(req.query.limit, 100, 1, 500);
         const lifecycle = req.query.lifecycle ? String(req.query.lifecycle) : undefined;
+        const serviceBranch = req.query.serviceBranch ? String(req.query.serviceBranch) : undefined;
         const excludeRetired = normalizeBooleanFlag(req.query.excludeRetired, false);
         res.json({
-            items: db.getValueBoard(limit, lifecycle, { excludeRetired }),
+            items: db.getValueBoard(limit, lifecycle, { excludeRetired, serviceBranch }),
         });
     });
 
@@ -386,6 +388,13 @@ function createRuntime(options = {}) {
         const excludeRetired = normalizeBooleanFlag(req.query.excludeRetired, false);
         res.json({
             items: db.getRankBoard({ excludeRetired }),
+        });
+    });
+
+    app.get('/v1/proxies/branches/board', (req, res) => {
+        const excludeRetired = normalizeBooleanFlag(req.query.excludeRetired, false);
+        res.json({
+            items: db.getServiceBranchDistribution?.({ excludeRetired }) || [],
         });
     });
 

--- a/apps/proxy-pool-service/src/server.test.js
+++ b/apps/proxy-pool-service/src/server.test.js
@@ -131,8 +131,9 @@ function createStubs() {
         getProxyList: () => [{ id: 1 }],
         getEvents: () => [{ id: 2 }],
         getBattleTestRuns: () => [{ id: 6, stage: 'l1' }],
-        getValueBoard: () => [{ id: 7, ip_value_score: 88.8 }],
+        getValueBoard: () => [{ id: 7, ip_value_score: 88.8, service_branch: '陆军' }],
         getRankBoard: () => [{ rank: '新兵', count: 1 }],
+        getServiceBranchDistribution: () => [{ service_branch: '陆军', count: 1 }],
         getRecruitCampBoard: () => [
             { lifecycle: 'active', label: '新兵连', count: 1 },
             { lifecycle: 'reserve', label: '医务室', count: 0 },
@@ -259,10 +260,12 @@ test('server runtime should expose all REST endpoints and shutdown cleanly', asy
         '/v1/proxies/pool-status',
         '/v1/proxies/list?limit=9999',
         '/v1/proxies/list?limit=10&rank=%E5%88%97%E5%85%B5&lifecycle=active',
+        '/v1/proxies/list?limit=10&serviceBranch=%E6%B5%B7%E5%86%9B',
         '/v1/proxies/events?limit=0',
         '/v1/proxies/battle-tests?limit=1000',
         '/v1/proxies/value-board?limit=20',
         '/v1/proxies/value-board?limit=20&lifecycle=active',
+        '/v1/proxies/value-board?limit=20&serviceBranch=%E6%B5%B7%E5%86%9B',
         '/v1/proxies/policy',
         '/v1/proxies/rollout',
         '/v1/proxies/rollout/guardrails',
@@ -270,6 +273,7 @@ test('server runtime should expose all REST endpoints and shutdown cleanly', asy
         '/v1/proxies/rollout/orchestrator/events',
         '/v1/proxies/candidate-control',
         '/v1/proxies/ranks/board',
+        '/v1/proxies/branches/board',
         '/v1/proxies/recruit-camp',
         '/v1/proxies/honors?limit=1000',
         '/v1/proxies/retirements?limit=-1',
@@ -438,6 +442,7 @@ test('excludeRetired flag should be forwarded to admin stats endpoints', async (
         source: [],
         lifecycle: [],
         rank: [],
+        branch: [],
         list: [],
         value: [],
     };
@@ -460,6 +465,10 @@ test('excludeRetired flag should be forwarded to admin stats endpoints', async (
         calls.rank.push(options);
         return [{ rank: '新兵', count: 1 }];
     };
+    stubs.db.getServiceBranchDistribution = (options) => {
+        calls.branch.push(options);
+        return [{ service_branch: '海军', count: 1 }];
+    };
     stubs.db.getProxyList = (options) => {
         calls.list.push(options);
         return [];
@@ -480,8 +489,9 @@ test('excludeRetired flag should be forwarded to admin stats endpoints', async (
         const poolStatusRes = await fetch(baseUrl + '/v1/proxies/pool-status?excludeRetired=true');
         const poolStatus = await poolStatusRes.json();
         await fetch(baseUrl + '/v1/proxies/ranks/board?excludeRetired=true');
-        await fetch(baseUrl + '/v1/proxies/list?limit=20&excludeRetired=true');
-        await fetch(baseUrl + '/v1/proxies/value-board?limit=20&excludeRetired=true');
+        await fetch(baseUrl + '/v1/proxies/branches/board?excludeRetired=true');
+        await fetch(baseUrl + '/v1/proxies/list?limit=20&excludeRetired=true&serviceBranch=%E6%B5%B7%E5%86%9B');
+        await fetch(baseUrl + '/v1/proxies/value-board?limit=20&excludeRetired=true&serviceBranch=%E6%B5%B7%E5%86%9B');
         await fetch(baseUrl + '/v1/proxies/list?limit=20&excludeRetired=off');
         await fetch(baseUrl + '/v1/proxies/list?limit=20&excludeRetired=not-bool');
         const campRes = await fetch(baseUrl + '/v1/proxies/recruit-camp');
@@ -490,10 +500,13 @@ test('excludeRetired flag should be forwarded to admin stats endpoints', async (
         assert.equal(calls.source.at(-1).excludeRetired, true);
         assert.equal(calls.lifecycle.at(-1).excludeRetired, true);
         assert.equal(calls.rank.at(-2).excludeRetired, true);
+        assert.equal(calls.branch.at(-1).excludeRetired, true);
         assert.equal(calls.list.at(-3).excludeRetired, true);
+        assert.equal(calls.list.at(-3).serviceBranch, '海军');
         assert.equal(calls.list.at(-2).excludeRetired, false);
         assert.equal(calls.list.at(-1).excludeRetired, false);
         assert.equal(calls.value.at(-1).options.excludeRetired, true);
+        assert.equal(calls.value.at(-1).options.serviceBranch, '海军');
         assert.deepEqual(poolStatus.latestSnapshot.source_distribution, [{ source: 'filtered-source', count: 1 }]);
         assert.deepEqual(poolStatus.latestSnapshot.rank_distribution, [{ rank: '新兵', count: 1 }]);
         assert.deepEqual(poolStatus.latestSnapshot.lifecycle_distribution, [{ lifecycle: 'active', count: 1 }]);
@@ -619,6 +632,21 @@ test('candidate control GET should prefer lifecycleCount when available', async 
         assert.equal(body.candidateCount, 5);
     } finally {
         await runtime.shutdown('TEST-CANDIDATE-CONTROL-LIFECYCLE-COUNT');
+    }
+});
+
+test('branches board endpoint should fallback when db method is missing', async () => {
+    const stubs = createStubs();
+    stubs.db.getServiceBranchDistribution = undefined;
+    const { runtime, baseUrl } = await startRuntimeOnRandomPort(stubs);
+
+    try {
+        const res = await fetch(baseUrl + '/v1/proxies/branches/board?excludeRetired=true');
+        assert.equal(res.status, 200);
+        const body = await res.json();
+        assert.deepEqual(body.items, []);
+    } finally {
+        await runtime.shutdown('TEST-BRANCH-BOARD-FALLBACK');
     }
 });
 

--- a/apps/proxy-pool-service/src/views/proxy-admin.html
+++ b/apps/proxy-pool-service/src/views/proxy-admin.html
@@ -232,10 +232,13 @@ async function loadAll() {
     const honorText = (x.honor_active || []).join('，') || '-';
     const address = x.ip ? (x.ip + ':' + x.port + '/' + x.protocol) : '-';
     const updatedUtc = x.updated_at || '-';
+    const displayName = x.display_name || '-';
+    const serviceBranch = x.service_branch || '陆军';
+    const displayNameWithBranch = displayName + ' [' + serviceBranch + ']';
     return ''
       + '<tr>'
       + '<td>' + (index + 1) + '</td>'
-      + '<td>' + esc(x.display_name) + '</td>'
+      + '<td>' + esc(displayNameWithBranch) + '</td>'
       + '<td>' + esc(x.rank) + '</td>'
       + '<td class="ok">' + fmtScore(x.ip_value_score) + '</td>'
       + '<td>' + esc(x.lifecycle) + '</td>'


### PR DESCRIPTION
## Summary
- add configurable service branch transitions in combat scoring (default rules for 陆军/海军/海豹突击队)
- persist service_branch and ranch_fail_streak in DB, with schema migration backfill for existing data
- add branch filters to list/value-board APIs and add /v1/proxies/branches/board distribution endpoint
- render value board names with branch suffix in admin UI (姓名 [编制])
- expand config/db/engine/server tests for branch logic and branch coverage thresholds

## Verification
- 
ode --test apps/proxy-pool-service/src/config.test.js apps/proxy-pool-service/src/engine.test.js
- 
pm run test:proxyhub:coverage (passes: lines/statements/functions 100, branches 98.05)

Closes #72