### PR TITLE
feat(proxyhub): add L3 browser battle layer and branch transitions (#70)

### DIFF
--- a/apps/proxy-pool-service/src/config.js
+++ b/apps/proxy-pool-service/src/config.js
@@ -210,6 +210,26 @@ const l2LookbackByProfile = {
     soak: 25,
 };
 
+const defaultBattleL3Targets = [
+    {
+        name: 'ly-flight-browser',
+        url: process.env.PROXY_HUB_BATTLE_L3_PRIMARY_URL
+            || process.env.PROXY_HUB_BATTLE_L2_PRIMARY_URL
+            || 'https://www.ly.com/flights/home',
+    },
+];
+const resolvedBattleL3Targets = parseJsonArrayEnv(
+    process.env.PROXY_HUB_BATTLE_L3_TARGETS_JSON,
+    defaultBattleL3Targets,
+).map((target) => ({
+    name: String(target?.name || target?.url || 'l3-target'),
+    url: String(target?.url || ''),
+})).filter((target) => target.url.length > 0);
+const resolvedBattleL3Protocols = String(process.env.PROXY_HUB_BATTLE_L3_ALLOWED_PROTOCOLS || 'http,https,socks5')
+    .split(',')
+    .map((protocol) => String(protocol || '').trim().toLowerCase())
+    .filter((protocol, index, list) => protocol.length > 0 && list.indexOf(protocol) === index);
+
 // 0232_hasOwnEnv_检查环境变量是否显式配置逻辑
 function hasOwnEnv(name) {
     return Object.prototype.hasOwnProperty.call(process.env, name);
@@ -457,6 +477,16 @@ module.exports = {
         timeoutMs: {
             l1: Number(process.env.PROXY_HUB_BATTLE_L1_TIMEOUT_MS || 5_000),
             l2: Number(process.env.PROXY_HUB_BATTLE_L2_TIMEOUT_MS || 8_000),
+        },
+        l3: {
+            enabled: toBool(process.env.PROXY_HUB_BATTLE_L3_ENABLED, true),
+            syncMs: Number(process.env.PROXY_HUB_BATTLE_L3_MS || 2_700_000),
+            maxPerCycle: Number(process.env.PROXY_HUB_BATTLE_L3_MAX || 12),
+            concurrency: Number(process.env.PROXY_HUB_BATTLE_L3_CONCURRENCY || 3),
+            lookbackMinutes: Number(process.env.PROXY_HUB_BATTLE_L3_LOOKBACK_MINUTES || l2LookbackByProfile[activeProfile]),
+            timeoutMs: Number(process.env.PROXY_HUB_BATTLE_L3_TIMEOUT_MS || 12_000),
+            allowedProtocols: deepClone(resolvedBattleL3Protocols),
+            targets: deepClone(resolvedBattleL3Targets),
         },
         blockedStatusCodes: [401, 403, 429, 503],
         blockSignals: [

--- a/apps/proxy-pool-service/src/config.test.js
+++ b/apps/proxy-pool-service/src/config.test.js
@@ -4,6 +4,15 @@ const assert = require('node:assert/strict');
 function loadConfigWithEnv(overrides = {}) {
     const managedKeys = new Set([
         'PROXY_HUB_BATTLE_L2_PRIMARY_URL',
+        'PROXY_HUB_BATTLE_L3_PRIMARY_URL',
+        'PROXY_HUB_BATTLE_L3_ENABLED',
+        'PROXY_HUB_BATTLE_L3_MS',
+        'PROXY_HUB_BATTLE_L3_MAX',
+        'PROXY_HUB_BATTLE_L3_CONCURRENCY',
+        'PROXY_HUB_BATTLE_L3_LOOKBACK_MINUTES',
+        'PROXY_HUB_BATTLE_L3_TIMEOUT_MS',
+        'PROXY_HUB_BATTLE_L3_ALLOWED_PROTOCOLS',
+        'PROXY_HUB_BATTLE_L3_TARGETS_JSON',
         'PROXY_HUB_FEATURE_STAGE_WEIGHTING',
         'PROXY_HUB_FEATURE_LIFECYCLE_HYSTERESIS',
         'PROXY_HUB_FEATURE_HONOR_PROMOTION_TUNING',
@@ -90,6 +99,13 @@ test('config should expose required default values', { concurrency: false }, () 
     assert.equal(config.battle.maxBattleL1PerCycle, 60);
     assert.equal(config.battle.maxBattleL2PerCycle, 20);
     assert.equal(config.battle.candidateQuota, 0.30);
+    assert.equal(config.battle.l3.enabled, true);
+    assert.equal(config.battle.l3.syncMs, 2700000);
+    assert.equal(config.battle.l3.maxPerCycle, 12);
+    assert.equal(config.battle.l3.concurrency, 3);
+    assert.equal(config.battle.l3.timeoutMs, 12000);
+    assert.equal(config.battle.l3.allowedProtocols.includes('socks5'), true);
+    assert.equal(config.battle.l3.targets[0].url, 'https://www.ly.com/flights/home');
     assert.equal(config.failureBackoff.enabled, true);
     assert.equal(config.failureBackoff.maxMs, 21600000);
     assert.equal(Array.isArray(config.battle.targets.l1), true);
@@ -112,6 +128,45 @@ test('config should support env override for L2 primary target', { concurrency: 
         PROXY_HUB_BATTLE_L2_PRIMARY_URL: 'https://example.com/l2-primary',
     });
     assert.equal(config.battle.targets.l2Primary[0].url, 'https://example.com/l2-primary');
+});
+
+test('config should support battle l3 env overrides', { concurrency: false }, () => {
+    const config = loadConfigWithEnv({
+        PROXY_HUB_BATTLE_L3_ENABLED: 'false',
+        PROXY_HUB_BATTLE_L3_MS: '600000',
+        PROXY_HUB_BATTLE_L3_MAX: '8',
+        PROXY_HUB_BATTLE_L3_CONCURRENCY: '2',
+        PROXY_HUB_BATTLE_L3_LOOKBACK_MINUTES: '45',
+        PROXY_HUB_BATTLE_L3_TIMEOUT_MS: '15000',
+        PROXY_HUB_BATTLE_L3_ALLOWED_PROTOCOLS: 'https,socks5',
+        PROXY_HUB_BATTLE_L3_TARGETS_JSON: JSON.stringify([
+            { name: 'l3-one', url: 'https://example.com/l3-1' },
+            { name: 'l3-two', url: 'https://example.com/l3-2' },
+        ]),
+    });
+    assert.equal(config.battle.l3.enabled, false);
+    assert.equal(config.battle.l3.syncMs, 600000);
+    assert.equal(config.battle.l3.maxPerCycle, 8);
+    assert.equal(config.battle.l3.concurrency, 2);
+    assert.equal(config.battle.l3.lookbackMinutes, 45);
+    assert.equal(config.battle.l3.timeoutMs, 15000);
+    assert.deepEqual(config.battle.l3.allowedProtocols, ['https', 'socks5']);
+    assert.equal(config.battle.l3.targets.length, 2);
+    assert.equal(config.battle.l3.targets[0].name, 'l3-one');
+});
+
+test('config should normalize battle l3 target and protocol env fallbacks', { concurrency: false }, () => {
+    const config = loadConfigWithEnv({
+        PROXY_HUB_BATTLE_L3_TARGETS_JSON: JSON.stringify([
+            { url: 'https://example.com/only-url' },
+            { name: '', url: 'https://example.com/empty-name' },
+            {},
+        ]),
+        PROXY_HUB_BATTLE_L3_ALLOWED_PROTOCOLS: 'https,,https,socks5',
+    });
+    assert.equal(config.battle.l3.targets.length, 2);
+    assert.equal(config.battle.l3.targets[0].name, 'https://example.com/only-url');
+    assert.deepEqual(config.battle.l3.allowedProtocols, ['https', 'socks5']);
 });
 
 test('config should support source override for line-based lists', { concurrency: false }, () => {

--- a/apps/proxy-pool-service/src/db.js
+++ b/apps/proxy-pool-service/src/db.js
@@ -730,6 +730,42 @@ class ProxyHubDb {
         `).all(cutoffIso, safeNowIso, safeLimit);
     }
 
+    // 0276_listProxiesForBattleL3_列出战场L3候选逻辑
+    listProxiesForBattleL3(limit, lookbackMinutes = 20, allowedProtocols = [], nowIso = new Date().toISOString()) {
+        const safeLimit = Math.max(0, Number(limit) || 0);
+        if (safeLimit === 0) return [];
+        const safeNowIso = normalizeIso(nowIso);
+
+        const cutoffIso = new Date(Date.parse(safeNowIso) - Math.max(1, Number(lookbackMinutes) || 1) * 60_000).toISOString();
+        const protocolList = Array.isArray(allowedProtocols)
+            ? allowedProtocols
+                .map((item) => String(item || '').trim().toLowerCase())
+                .filter((item) => item.length > 0)
+            : [];
+        const protocolFilterSql = protocolList.length > 0
+            ? ` AND p.protocol IN (${protocolList.map(() => '?').join(',')})`
+            : '';
+
+        return this.db.prepare(`
+            SELECT p.*
+            FROM proxies p
+            INNER JOIN (
+                SELECT proxy_id, MAX(timestamp) AS latest_l2_success_at
+                FROM battle_test_runs
+                WHERE stage = 'l2' AND outcome = 'success' AND timestamp >= ?
+                GROUP BY proxy_id
+            ) l2 ON l2.proxy_id = p.id
+            WHERE p.lifecycle != 'retired'
+              AND (p.backoff_until IS NULL OR p.backoff_until <= ?)
+              ${protocolFilterSql}
+            ORDER BY
+                COALESCE(p.last_battle_checked_at, '1970-01-01T00:00:00.000Z') ASC,
+                CASE p.lifecycle WHEN 'active' THEN 0 WHEN 'reserve' THEN 1 WHEN 'candidate' THEN 2 ELSE 3 END ASC,
+                l2.latest_l2_success_at DESC
+            LIMIT ?
+        `).all(cutoffIso, safeNowIso, ...protocolList, safeLimit);
+    }
+
     // 0009_listProxiesForStateReview_列出状态巡检逻辑
     listProxiesForStateReview(limit) {
         return this.db.prepare(`

--- a/apps/proxy-pool-service/src/db.test.js
+++ b/apps/proxy-pool-service/src/db.test.js
@@ -585,7 +585,7 @@ test('value board API should sort by value and parse breakdown and honor fields'
     cleanup(h);
 });
 
-test('battle APIs should persist run details and support L1/L2 candidate selection', () => {
+test('battle APIs should persist run details and support L1/L2/L3 candidate selection', () => {
     const h = createDb();
     const now = new Date().toISOString();
 
@@ -627,9 +627,45 @@ test('battle APIs should persist run details and support L1/L2 candidate selecti
     const l2Candidates = h.db.listProxiesForBattleL2(2, 10);
     assert.equal(l2Candidates.some((item) => item.id === all[0].id), true);
 
+    h.db.insertBattleTestRun({
+        timestamp: now,
+        proxy_id: all[1].id,
+        stage: 'l2',
+        target: 'ly-browser',
+        outcome: 'success',
+        status_code: 200,
+        latency_ms: 60,
+        reason: 'ok',
+        details: { mode: 'browser' },
+    });
+    h.db.insertBattleTestRun({
+        timestamp: now,
+        proxy_id: all[2].id,
+        stage: 'l2',
+        target: 'ly-browser',
+        outcome: 'success',
+        status_code: 200,
+        latency_ms: 65,
+        reason: 'ok',
+        details: { mode: 'browser' },
+    });
+    h.db.updateProxyById(all[2].id, { protocol: 'socks4', updated_at: now });
+
+    const l3HttpCandidates = h.db.listProxiesForBattleL3(5, 10, ['http']);
+    assert.equal(l3HttpCandidates.some((item) => item.id === all[1].id), true);
+    assert.equal(l3HttpCandidates.some((item) => item.id === all[2].id), false);
+    const l3WithNullableProtocol = h.db.listProxiesForBattleL3(5, 10, ['http', null]);
+    assert.equal(l3WithNullableProtocol.some((item) => item.id === all[1].id), true);
+    const l3AllCandidates = h.db.listProxiesForBattleL3(5, 10, []);
+    assert.equal(l3AllCandidates.some((item) => item.id === all[2].id), true);
+    const l3FallbackArgs = h.db.listProxiesForBattleL3(5, 'bad', null, 'invalid-now');
+    assert.equal(Array.isArray(l3FallbackArgs), true);
+    assert.deepEqual(h.db.listProxiesForBattleL3(0, 10, ['http']), []);
+
     const runs = h.db.getBattleTestRuns(5);
-    assert.equal(runs.length, 1);
-    assert.equal(runs[0].stage, 'l1');
+    assert.equal(runs.length, 3);
+    assert.equal(runs.some((run) => run.stage === 'l1'), true);
+    assert.equal(runs.some((run) => run.stage === 'l2'), true);
 
     cleanup(h);
 });
@@ -684,6 +720,25 @@ test('candidate selectors should skip proxies in failure backoff window', () => 
 
     const l2Candidates = h.db.listProxiesForBattleL2(3, 120, now);
     assert.equal(l2Candidates.some((item) => item.id === all[1].id), false);
+
+    h.db.insertBattleTestRun({
+        timestamp: now,
+        proxy_id: all[2].id,
+        stage: 'l2',
+        target: 'ly',
+        outcome: 'success',
+        status_code: 200,
+        latency_ms: 50,
+        reason: 'ok',
+        details: {},
+    });
+    h.db.updateProxyById(all[2].id, {
+        backoff_until: future,
+        backoff_reason: 'l3:network_error',
+        updated_at: now,
+    });
+    const l3Candidates = h.db.listProxiesForBattleL3(3, 120, ['http'], now);
+    assert.equal(l3Candidates.some((item) => item.id === all[2].id), false);
 
     cleanup(h);
 });

--- a/apps/proxy-pool-service/src/engine.js
+++ b/apps/proxy-pool-service/src/engine.js
@@ -422,12 +422,14 @@ class ProxyHubEngine extends EventEmitter {
         this.snapshotTimer = null;
         this.battleL1Timer = null;
         this.battleL2Timer = null;
+        this.battleL3Timer = null;
         this.candidateSweepTimer = null;
 
         this.isSourceCycleRunning = false;
         this.isStateReviewRunning = false;
         this.isBattleL1Running = false;
         this.isBattleL2Running = false;
+        this.isBattleL3Running = false;
         this.isCandidateSweepRunning = false;
         this.threadPoolAlerting = false;
     }
@@ -435,6 +437,11 @@ class ProxyHubEngine extends EventEmitter {
     // 0210_isBattleEnabled_判断战场测试开关逻辑
     isBattleEnabled() {
         return this.config?.battle?.enabled === true;
+    }
+
+    // 0278_isBattleL3Enabled_判断战场L3开关逻辑
+    isBattleL3Enabled() {
+        return this.isBattleEnabled() && this.config?.battle?.l3?.enabled === true;
     }
 
     // 0028_start_启动逻辑
@@ -451,6 +458,9 @@ class ProxyHubEngine extends EventEmitter {
         if (this.isBattleEnabled()) {
             await this.runBattleL1Cycle();
             await this.runBattleL2Cycle();
+            if (this.isBattleL3Enabled()) {
+                await this.runBattleL3Cycle();
+            }
         }
         this.persistSnapshot();
 
@@ -475,6 +485,11 @@ class ProxyHubEngine extends EventEmitter {
             this.battleL2Timer = setInterval(() => {
                 void this.runBattleL2Cycle();
             }, this.config.battle.l2SyncMs);
+            if (this.isBattleL3Enabled()) {
+                this.battleL3Timer = setInterval(() => {
+                    void this.runBattleL3Cycle();
+                }, this.config.battle.l3.syncMs);
+            }
         }
 
         this.snapshotTimer = setInterval(() => {
@@ -487,7 +502,7 @@ class ProxyHubEngine extends EventEmitter {
             result: 'ProxyHub 已启动',
             reason: `抓源间隔 ${Math.round(this.config.scheduler.sourceSyncMs / 1000)} 秒`,
             action: this.isBattleEnabled()
-                ? `L1 ${Math.round(this.config.battle.l1SyncMs / 1000)} 秒, L2 ${Math.round(this.config.battle.l2SyncMs / 1000)} 秒`
+                ? `L1 ${Math.round(this.config.battle.l1SyncMs / 1000)} 秒, L2 ${Math.round(this.config.battle.l2SyncMs / 1000)} 秒${this.isBattleL3Enabled() ? `, L3 ${Math.round(this.config.battle.l3.syncMs / 1000)} 秒` : ''}`
                 : '调度循环启动',
         });
     }
@@ -514,6 +529,10 @@ class ProxyHubEngine extends EventEmitter {
         if (this.battleL2Timer) {
             clearInterval(this.battleL2Timer);
             this.battleL2Timer = null;
+        }
+        if (this.battleL3Timer) {
+            clearInterval(this.battleL3Timer);
+            this.battleL3Timer = null;
         }
         if (this.candidateSweepTimer) {
             clearInterval(this.candidateSweepTimer);
@@ -754,6 +773,7 @@ class ProxyHubEngine extends EventEmitter {
         nowIso,
         stage,
         combatStage = 'l1',
+        branchingStage = combatStage,
         extraUpdates = {},
     }) {
         const currentProxy = this.db.getProxyById(proxyId);
@@ -771,7 +791,7 @@ class ProxyHubEngine extends EventEmitter {
         });
         const branchTransition = resolveBranchingTransition({
             proxy: currentProxy,
-            stage: combatStage,
+            stage: branchingStage,
             outcome,
             config: this.config,
         });
@@ -1222,6 +1242,109 @@ class ProxyHubEngine extends EventEmitter {
             });
         } finally {
             this.isBattleL2Running = false;
+        }
+    }
+
+    // 0279_runBattleL3Cycle_执行战场L3轮次逻辑
+    async runBattleL3Cycle() {
+        if (!this.started || !this.isBattleL3Enabled() || this.isBattleL3Running) {
+            return;
+        }
+
+        this.isBattleL3Running = true;
+        const sourceName = 'battle-l3-browser';
+        const l3Config = this.config?.battle?.l3 || {};
+
+        try {
+            const candidates = this.db.listProxiesForBattleL3(
+                l3Config.maxPerCycle,
+                l3Config.lookbackMinutes,
+                l3Config.allowedProtocols,
+            );
+            if (candidates.length === 0) {
+                return;
+            }
+
+            const concurrency = Math.max(1, Math.min(Number(l3Config.concurrency) || 1, 6));
+            await runWithConcurrency(candidates, concurrency, async (proxy) => {
+                const nowIso = this.now().toISOString();
+                try {
+                    const result = await this.workerPool.runTask('battle-l3-browser', {
+                        proxy: {
+                            ip: proxy.ip,
+                            port: proxy.port,
+                            protocol: proxy.protocol,
+                        },
+                        targets: l3Config.targets,
+                        timeoutMs: l3Config.timeoutMs,
+                        blockedStatusCodes: this.config.battle.blockedStatusCodes,
+                        blockSignals: this.config.battle.blockSignals,
+                        allowedProtocols: l3Config.allowedProtocols,
+                    });
+
+                    for (const run of result.runs || []) {
+                        this.db.insertBattleTestRun({
+                            timestamp: nowIso,
+                            proxy_id: proxy.id,
+                            stage: 'l3',
+                            target: run.target,
+                            outcome: run.outcome,
+                            status_code: run.statusCode,
+                            latency_ms: run.latencyMs,
+                            reason: run.reason,
+                            details: run.details,
+                        });
+                    }
+
+                    const latest = this.db.getProxyById(proxy.id);
+                    const battleUpdates = buildBattleCounterUpdates(latest || proxy, nowIso, result.outcome, 'l2');
+                    await this.applyCombatOutcome({
+                        proxyId: proxy.id,
+                        sourceName,
+                        outcome: result.outcome,
+                        latencyMs: result.latencyMs || 0,
+                        nowIso,
+                        stage: '评分(L3)',
+                        combatStage: 'l2',
+                        branchingStage: 'l3',
+                        extraUpdates: battleUpdates,
+                    });
+                } catch (error) {
+                    const latest = this.db.getProxyById(proxy.id) || proxy;
+                    const battleUpdates = buildBattleCounterUpdates(latest, nowIso, 'network_error', 'l2');
+                    await this.applyCombatOutcome({
+                        proxyId: proxy.id,
+                        sourceName,
+                        outcome: 'network_error',
+                        latencyMs: 0,
+                        nowIso,
+                        stage: '评分(L3-异常)',
+                        combatStage: 'l2',
+                        branchingStage: 'l3',
+                        extraUpdates: battleUpdates,
+                    });
+
+                    this.logger.write({
+                        event: '战场测试L3失败',
+                        proxyName: proxy.display_name,
+                        ipSource: sourceName,
+                        stage: '战场测试L3',
+                        result: '异常',
+                        reason: error?.message || 'battle-l3-task-error',
+                        action: '已触发失败退避',
+                    });
+                }
+            });
+        } catch (error) {
+            this.logger.write({
+                event: '线程池告警',
+                stage: '战场测试L3',
+                result: '异常',
+                reason: error?.message || 'battle-l3-error',
+                action: '等待自动恢复',
+            });
+        } finally {
+            this.isBattleL3Running = false;
         }
     }
 

--- a/apps/proxy-pool-service/src/engine.test.js
+++ b/apps/proxy-pool-service/src/engine.test.js
@@ -37,6 +37,16 @@ function createConfig(dbPath) {
             candidateQuota: 0.15,
             l2LookbackMinutes: 10,
             timeoutMs: { l1: 5000, l2: 8000 },
+            l3: {
+                enabled: true,
+                syncMs: 2700000,
+                maxPerCycle: 12,
+                concurrency: 3,
+                lookbackMinutes: 10,
+                timeoutMs: 12000,
+                allowedProtocols: ['http', 'https', 'socks5'],
+                targets: [{ name: 'ly-browser', url: 'https://www.ly.com/flights/home' }],
+            },
             blockedStatusCodes: [401, 403, 429, 503],
             blockSignals: ['captcha'],
             targets: {
@@ -988,11 +998,15 @@ test('engine start should schedule battle timers when enabled', async () => {
     const engine = new ProxyHubEngine({ config: h.config, db: h.db, workerPool, logger, now: () => new Date('2026-03-14T00:00:00.000Z') });
     let l1Calls = 0;
     let l2Calls = 0;
+    let l3Calls = 0;
     engine.runBattleL1Cycle = async () => {
         l1Calls += 1;
     };
     engine.runBattleL2Cycle = async () => {
         l2Calls += 1;
+    };
+    engine.runBattleL3Cycle = async () => {
+        l3Calls += 1;
     };
 
     await engine.start();
@@ -1001,9 +1015,10 @@ test('engine start should schedule battle timers when enabled', async () => {
     global.setInterval = oldSetInterval;
     global.clearInterval = oldClearInterval;
 
-    assert.equal(timers.length, 6);
+    assert.equal(timers.length, 7);
     assert.equal(l1Calls >= 2, true);
     assert.equal(l2Calls >= 2, true);
+    assert.equal(l3Calls >= 2, true);
     cleanupDb(h);
 });
 
@@ -1510,6 +1525,58 @@ test('applyCombatOutcome should apply l2 branch transfer and fallback rules', as
     cleanupDb(h);
 });
 
+test('applyCombatOutcome should score L3 with L2 weight while applying L3 branch transition', async () => {
+    const h = createDbHandle();
+    const logger = createLogger();
+    const now = '2026-03-14T11:00:00.000Z';
+    h.config.policy.scoring.stageMultipliers = {
+        score: { l1: 1, l2: 2 },
+        health: { l1: 1, l2: 1 },
+    };
+    h.config.rollout = {
+        features: {
+            stageWeighting: true,
+            lifecycleHysteresis: false,
+            honorPromotionTuning: false,
+        },
+    };
+    h.db.upsertSourceBatch(
+        [{ ip: '10.0.0.92', port: 8080, protocol: 'http' }],
+        () => '编制-L3-92',
+        'src',
+        'batch',
+        now,
+    );
+    const proxy = h.db.getProxyList({ limit: 1 })[0];
+
+    const workerPool = {
+        async runTask() {
+            return { ok: true };
+        },
+        getStatus() {
+            return { workersTotal: 1, workersBusy: 0, queueSize: 0, runningTasks: 0, completedTasks: 0, failedTasks: 0, restartedWorkers: 0, workers: [] };
+        },
+    };
+    const engine = new ProxyHubEngine({ config: h.config, db: h.db, workerPool, logger });
+
+    await engine.applyCombatOutcome({
+        proxyId: proxy.id,
+        sourceName: 'battle-l3-browser',
+        outcome: 'success',
+        latencyMs: 20,
+        nowIso: '2026-03-14T11:00:00.000Z',
+        stage: '评分(L3)',
+        combatStage: 'l2',
+        branchingStage: 'l3',
+    });
+
+    const updated = h.db.getProxyById(proxy.id);
+    assert.equal(updated.combat_points, 12);
+    assert.equal(updated.service_branch, '海豹突击队');
+    assert.equal(h.db.getEvents(20).some((item) => item.event_type === 'branch_transfer'), true);
+    cleanupDb(h);
+});
+
 test('runBattleL1Cycle should cover guard and error branches', async () => {
     const h = createDbHandle();
     const logger = createLogger();
@@ -1735,6 +1802,176 @@ test('runBattleL2Cycle should return early when there are no candidates', async 
     assert.equal(engine.isBattleL2Running, false);
 });
 
+test('runBattleL3Cycle should process candidates and cover guard/error branches', async () => {
+    const h = createDbHandle();
+    const logger = createLogger();
+    h.config.battle.enabled = true;
+    h.config.battle.l3.enabled = true;
+    const now = new Date().toISOString();
+    h.db.upsertSourceBatch(
+        [{ ip: '10.0.0.51', port: 8080, protocol: 'http' }],
+        () => '战场-L3-51',
+        'src',
+        'batch',
+        now,
+    );
+    const proxy = h.db.getProxyList({ limit: 1 })[0];
+    h.db.updateProxyById(proxy.id, { lifecycle: 'active', updated_at: now });
+    h.db.insertBattleTestRun({
+        timestamp: now,
+        proxy_id: proxy.id,
+        stage: 'l2',
+        target: 'ly',
+        outcome: 'success',
+        status_code: 200,
+        latency_ms: 20,
+        reason: 'ok',
+        details: {},
+    });
+
+    let mode = 'success';
+    const workerPool = {
+        async runTask(type) {
+            if (type === 'battle-l3-browser') {
+                if (mode === 'throw-message') {
+                    throw new Error('battle-l3-boom');
+                }
+                if (mode === 'throw-null') {
+                    throw null;
+                }
+                if (mode === 'no-runs') {
+                    return {
+                        stage: 'l3',
+                        outcome: 'network_error',
+                    };
+                }
+                return {
+                    stage: 'l3',
+                    outcome: 'success',
+                    latencyMs: 21,
+                    runs: [{ target: 'ly-browser', outcome: 'success', statusCode: 200, latencyMs: 21, reason: 'browser_ok', details: {} }],
+                };
+            }
+            return { ok: true };
+        },
+        getStatus() {
+            return { workersTotal: 2, workersBusy: 0, queueSize: 0, runningTasks: 0, completedTasks: 0, failedTasks: 0, restartedWorkers: 0, workers: [] };
+        },
+    };
+
+    const engine = new ProxyHubEngine({ config: h.config, db: h.db, workerPool, logger, now: () => new Date('2026-03-14T07:30:00.000Z') });
+
+    engine.started = false;
+    await engine.runBattleL3Cycle();
+
+    engine.started = true;
+    engine.isBattleL3Running = true;
+    await engine.runBattleL3Cycle();
+    engine.isBattleL3Running = false;
+
+    await engine.runBattleL3Cycle();
+    const runs = h.db.getBattleTestRuns(10);
+    assert.equal(runs.some((run) => run.stage === 'l3'), true);
+
+    mode = 'throw-message';
+    await engine.runBattleL3Cycle();
+    assert.equal(logger.entries.some((entry) => entry.event === '战场测试L3失败' && entry.stage === '战场测试L3' && entry.reason === 'battle-l3-boom'), true);
+
+    mode = 'throw-null';
+    await engine.runBattleL3Cycle();
+    assert.equal(logger.entries.some((entry) => entry.event === '战场测试L3失败' && entry.stage === '战场测试L3' && entry.reason === 'battle-l3-task-error'), true);
+
+    const oldGetById = h.db.getProxyById.bind(h.db);
+    h.db.getProxyById = () => null;
+    mode = 'throw-message';
+    await engine.runBattleL3Cycle();
+    mode = 'no-runs';
+    h.db.getProxyById = oldGetById;
+    await engine.runBattleL3Cycle();
+    h.db.getProxyById = () => null;
+    await engine.runBattleL3Cycle();
+    h.db.getProxyById = oldGetById;
+    assert.equal(logger.entries.some((entry) => entry.event === '战场测试L3失败' && entry.reason === 'battle-l3-boom'), true);
+
+    cleanupDb(h);
+});
+
+test('runBattleL3Cycle should return early when disabled or there are no candidates', async () => {
+    const logger = createLogger();
+    const config = createConfig(path.join(os.tmpdir(), 'proxyhub-engine-l3-empty.db'));
+    config.battle.enabled = true;
+
+    let runTaskCalls = 0;
+    const db = {
+        listProxiesForBattleL3() {
+            return [];
+        },
+    };
+    const workerPool = {
+        async runTask() {
+            runTaskCalls += 1;
+            return { ok: true };
+        },
+        getStatus() {
+            return { workersTotal: 2, workersBusy: 0, queueSize: 0, runningTasks: 0, completedTasks: 0, failedTasks: 0, restartedWorkers: 0, workers: [] };
+        },
+    };
+
+    const engine = new ProxyHubEngine({ config, db, workerPool, logger });
+    engine.started = true;
+    config.battle.l3.enabled = false;
+    await engine.runBattleL3Cycle();
+    config.battle.l3.enabled = true;
+    await engine.runBattleL3Cycle();
+
+    assert.equal(runTaskCalls, 0);
+    assert.equal(engine.isBattleL3Running, false);
+});
+
+test('runBattleL3Cycle should fallback l3 config object and concurrency defaults', async () => {
+    const logger = createLogger();
+    const config = createConfig(path.join(os.tmpdir(), 'proxyhub-engine-l3-fallback.db'));
+    config.battle.enabled = true;
+    config.battle.l3 = undefined;
+
+    let runTaskCalls = 0;
+    const db = {
+        listProxiesForBattleL3() {
+            return [{ id: 1, ip: '10.0.0.1', port: 8080, protocol: 'http', display_name: 'L3-兜底-1' }];
+        },
+        getProxyById() {
+            return { id: 1, battle_success_count: 0, battle_fail_count: 0 };
+        },
+        insertBattleTestRun() {},
+    };
+    const workerPool = {
+        async runTask(type, payload) {
+            assert.equal(type, 'battle-l3-browser');
+            assert.equal(payload.timeoutMs, undefined);
+            runTaskCalls += 1;
+            return {
+                stage: 'l3',
+                outcome: 'success',
+                latencyMs: 12,
+                runs: [],
+            };
+        },
+        getStatus() {
+            return { workersTotal: 1, workersBusy: 0, queueSize: 0, runningTasks: 0, completedTasks: 0, failedTasks: 0, restartedWorkers: 0, workers: [] };
+        },
+    };
+
+    const engine = new ProxyHubEngine({ config, db, workerPool, logger, now: () => new Date('2026-03-14T08:00:00.000Z') });
+    engine.started = true;
+    engine.isBattleL3Enabled = () => true;
+    engine.applyCombatOutcome = async () => {};
+
+    await engine.runBattleL3Cycle();
+
+    assert.equal(runTaskCalls, 1);
+    assert.equal(engine.isBattleL3Running, false);
+});
+
 test('runBattle cycles should log outer-catch fallback reason when candidate listing throws', async () => {
     const logger = createLogger();
     const config = createConfig(path.join(os.tmpdir(), 'proxyhub-engine-battle-outer.db'));
@@ -1754,6 +1991,12 @@ test('runBattle cycles should log outer-catch fallback reason when candidate lis
             }
             throw new Error('battle-l2-list-fail');
         },
+        listProxiesForBattleL3() {
+            if (throwMode === 'null') {
+                throw null;
+            }
+            throw new Error('battle-l3-list-fail');
+        },
     };
     const workerPool = {
         async runTask() {
@@ -1768,15 +2011,19 @@ test('runBattle cycles should log outer-catch fallback reason when candidate lis
 
     await engine.runBattleL1Cycle();
     await engine.runBattleL2Cycle();
+    await engine.runBattleL3Cycle();
 
     assert.equal(logger.entries.some((e) => e.event === '线程池告警' && e.stage === '战场测试L1' && e.reason === 'battle-l1-error'), true);
     assert.equal(logger.entries.some((e) => e.event === '线程池告警' && e.stage === '战场测试L2' && e.reason === 'battle-l2-error'), true);
+    assert.equal(logger.entries.some((e) => e.event === '线程池告警' && e.stage === '战场测试L3' && e.reason === 'battle-l3-error'), true);
 
     throwMode = 'message';
     await engine.runBattleL1Cycle();
     await engine.runBattleL2Cycle();
+    await engine.runBattleL3Cycle();
     assert.equal(logger.entries.some((e) => e.event === '线程池告警' && e.stage === '战场测试L1' && e.reason === 'battle-l1-list-fail'), true);
     assert.equal(logger.entries.some((e) => e.event === '线程池告警' && e.stage === '战场测试L2' && e.reason === 'battle-l2-list-fail'), true);
+    assert.equal(logger.entries.some((e) => e.event === '线程池告警' && e.stage === '战场测试L3' && e.reason === 'battle-l3-list-fail'), true);
 });
 
 test('runSourceCycle should audit manual override gate branch', async () => {

--- a/apps/proxy-pool-service/src/worker.js
+++ b/apps/proxy-pool-service/src/worker.js
@@ -610,6 +610,167 @@ async function runBattleL2Task(payload, deps = {}) {
     };
 }
 
+// 0277_runBattleL3BrowserTask_执行战场L3浏览器实战逻辑
+async function runBattleL3BrowserTask(payload, deps = {}) {
+    const timeoutMs = Number(payload.timeoutMs || 12000);
+    const blockedStatusCodes = payload.blockedStatusCodes || [];
+    const blockSignals = payload.blockSignals || [];
+    const targets = Array.isArray(payload.targets) ? payload.targets : [];
+    const runs = [];
+    const allowedProtocols = Array.isArray(payload.allowedProtocols)
+        ? payload.allowedProtocols.map((item) => String(item || '').toLowerCase())
+        : [];
+    const proxyProtocol = String(payload?.proxy?.protocol || '').toLowerCase();
+
+    if (targets.length === 0) {
+        return {
+            stage: 'l3',
+            outcome: 'invalid_feedback',
+            latencyMs: 0,
+            reason: 'missing_targets',
+            runs,
+        };
+    }
+
+    if (allowedProtocols.length > 0 && !allowedProtocols.includes(proxyProtocol)) {
+        return {
+            stage: 'l3',
+            outcome: 'invalid_feedback',
+            latencyMs: 0,
+            reason: 'protocol_not_allowed',
+            runs: [{
+                target: targets[0].name || targets[0].url,
+                outcome: 'invalid_feedback',
+                statusCode: null,
+                latencyMs: 0,
+                reason: 'protocol_not_allowed',
+                details: { protocol: proxyProtocol },
+            }],
+        };
+    }
+
+    const launchOptions = {
+        headless: true,
+    };
+    if (payload?.proxy?.ip && payload?.proxy?.port) {
+        launchOptions.proxy = {
+            server: buildProxyUrl(payload.proxy),
+        };
+    }
+    let launchBrowser = deps.launchBrowser;
+    if (!launchBrowser) {
+        const camoufoxModule = deps.camoufoxModule || require('camoufox');
+        launchBrowser = camoufoxModule.Camoufox || camoufoxModule;
+    }
+    const browser = await launchBrowser(launchOptions);
+
+    try {
+        for (const target of targets) {
+            const page = await browser.newPage();
+            const started = Date.now();
+            try {
+                const response = await page.goto(target.url, {
+                    waitUntil: 'domcontentloaded',
+                    timeout: timeoutMs,
+                });
+                const statusCode = Number(
+                    response && typeof response.status === 'function'
+                        ? response.status()
+                        : response?.statusCode || 0,
+                );
+                const body = typeof page.content === 'function' ? await page.content() : '';
+                const blockedBySignal = blockedStatusCodes.includes(statusCode) || hasBlockSignal(body, blockSignals);
+
+                if (blockedBySignal) {
+                    runs.push({
+                        target: target.name || target.url,
+                        outcome: 'blocked',
+                        statusCode,
+                        latencyMs: Date.now() - started,
+                        reason: 'blocked_signal',
+                        details: {},
+                    });
+                } else if (statusCode < 200 || statusCode >= 300) {
+                    runs.push({
+                        target: target.name || target.url,
+                        outcome: 'invalid_feedback',
+                        statusCode,
+                        latencyMs: Date.now() - started,
+                        reason: 'non_2xx',
+                        details: {},
+                    });
+                } else if (String(body || '').trim().length < 20) {
+                    runs.push({
+                        target: target.name || target.url,
+                        outcome: 'invalid_feedback',
+                        statusCode,
+                        latencyMs: Date.now() - started,
+                        reason: 'content_assert_failed',
+                        details: {},
+                    });
+                } else {
+                    runs.push({
+                        target: target.name || target.url,
+                        outcome: 'success',
+                        statusCode,
+                        latencyMs: Date.now() - started,
+                        reason: 'browser_ok',
+                        details: {},
+                    });
+                }
+            } catch (error) {
+                const reason = error?.message || 'browser_error';
+                const timeoutMatched = String(reason).toLowerCase().includes('timeout');
+                runs.push({
+                    target: target.name || target.url,
+                    outcome: timeoutMatched ? 'timeout' : 'network_error',
+                    statusCode: null,
+                    latencyMs: Date.now() - started,
+                    reason,
+                    details: {},
+                });
+            } finally {
+                if (typeof page.close === 'function') {
+                    try {
+                        await page.close();
+                    } catch {}
+                }
+            }
+        }
+    } finally {
+        if (browser && typeof browser.close === 'function') {
+            try {
+                await browser.close();
+            } catch {}
+        }
+    }
+
+    const hasSuccess = runs.some((item) => item.outcome === 'success');
+    let outcome = 'network_error';
+    if (hasSuccess) {
+        outcome = 'success';
+    } else if (runs.some((item) => item.outcome === 'blocked')) {
+        outcome = 'blocked';
+    } else if (runs.some((item) => item.outcome === 'timeout')) {
+        outcome = 'timeout';
+    } else if (runs.some((item) => item.outcome === 'invalid_feedback')) {
+        outcome = 'invalid_feedback';
+    }
+
+    const avgLatency = Math.round(
+        runs.reduce((sum, item) => sum + (item.latencyMs || 0), 0)
+        / Math.max(1, runs.length),
+    );
+
+    return {
+        stage: 'l3',
+        outcome,
+        latencyMs: avgLatency,
+        reason: hasSuccess ? 'at_least_one_target_success' : 'all_targets_failed',
+        runs,
+    };
+}
+
 // 0158_handleTask_处理任务逻辑
 async function handleTask(type, payload, deps = {}) {
     if (type === 'fetch-source') {
@@ -626,6 +787,9 @@ async function handleTask(type, payload, deps = {}) {
     }
     if (type === 'battle-l2') {
         return runBattleL2Task(payload, deps);
+    }
+    if (type === 'battle-l3-browser') {
+        return runBattleL3BrowserTask(payload, deps);
     }
     if (type === 'state-transition') {
         return stateTransitionTask(payload, deps);
@@ -676,6 +840,7 @@ module.exports = {
     isL2ContentValid,
     isFallbackContentValid,
     runBattleL2Task,
+    runBattleL3BrowserTask,
     handleTask,
     attachWorkerListener,
 };

--- a/apps/proxy-pool-service/src/worker.test.js
+++ b/apps/proxy-pool-service/src/worker.test.js
@@ -25,6 +25,7 @@ const {
     isL2ContentValid,
     isFallbackContentValid,
     runBattleL2Task,
+    runBattleL3BrowserTask,
     handleTask,
     attachWorkerListener,
 } = require('./worker');
@@ -375,6 +376,32 @@ function createFakeRequestLib(steps) {
     };
 }
 
+function createFakeBrowserLauncher(steps) {
+    const seq = [...steps];
+    return async () => ({
+        async newPage() {
+            const step = seq.shift() || {};
+            return {
+                async goto() {
+                    if (step.throwError) {
+                        throw step.throwError;
+                    }
+                    return {
+                        status() {
+                            return step.statusCode ?? 200;
+                        },
+                    };
+                },
+                async content() {
+                    return step.body ?? '';
+                },
+                async close() {},
+            };
+        },
+        async close() {},
+    });
+}
+
 test('requestThroughProxy should return success and error branches', async () => {
     const okResult = await requestThroughProxy({
         proxy: { protocol: 'http', ip: '1.1.1.1', port: 80 },
@@ -626,6 +653,254 @@ test('battle L2 task should classify blocked/network_error/success branches', as
     assert.equal(fallbackInvalid.runs[1].reason, 'fallback_assert_failed');
 });
 
+test('battle L3 browser task should classify success/blocked/timeout and guard branches', async () => {
+    const success = await runBattleL3BrowserTask({
+        proxy: { protocol: 'http', ip: '1.1.1.1', port: 80 },
+        targets: [{ name: 'ly-browser', url: 'https://www.ly.com/flights/home' }],
+        timeoutMs: 50,
+        blockedStatusCodes: [403],
+        blockSignals: ['captcha'],
+        allowedProtocols: ['http', 'https'],
+    }, {
+        camoufoxModule: {
+            Camoufox: createFakeBrowserLauncher([
+                { statusCode: 200, body: 'ly browser content long enough for assert' },
+            ]),
+        },
+    });
+    assert.equal(success.stage, 'l3');
+    assert.equal(success.outcome, 'success');
+    assert.equal(success.runs[0].reason, 'browser_ok');
+
+    const blocked = await runBattleL3BrowserTask({
+        proxy: { protocol: 'http', ip: '1.1.1.1', port: 80 },
+        targets: [{ name: 'ly-browser', url: 'https://www.ly.com/flights/home' }],
+        timeoutMs: 50,
+        blockedStatusCodes: [403],
+        blockSignals: ['captcha'],
+        allowedProtocols: ['http', 'https'],
+    }, {
+        launchBrowser: createFakeBrowserLauncher([
+            { statusCode: 403, body: 'blocked' },
+        ]),
+    });
+    assert.equal(blocked.outcome, 'blocked');
+
+    const timeout = await runBattleL3BrowserTask({
+        proxy: { protocol: 'http', ip: '1.1.1.1', port: 80 },
+        targets: [
+            { name: 't1', url: 'https://x.test' },
+            { name: 't2', url: 'https://y.test' },
+        ],
+        timeoutMs: 50,
+        blockedStatusCodes: [],
+        blockSignals: [],
+        allowedProtocols: ['http'],
+    }, {
+        launchBrowser: createFakeBrowserLauncher([
+            { throwError: new Error('timeout 5000ms exceeded') },
+            { statusCode: 200, body: 'short' },
+        ]),
+    });
+    assert.equal(timeout.outcome, 'timeout');
+    assert.equal(timeout.runs[0].outcome, 'timeout');
+
+    const non2xx = await runBattleL3BrowserTask({
+        proxy: { protocol: 'http', ip: '1.1.1.1', port: 80 },
+        targets: [{ name: 't3', url: 'https://z.test' }],
+        timeoutMs: 50,
+        blockedStatusCodes: [],
+        blockSignals: [],
+        allowedProtocols: ['http'],
+    }, {
+        launchBrowser: async () => ({
+            async newPage() {
+                return {
+                    async goto() {
+                        return { statusCode: 500 };
+                    },
+                };
+            },
+        }),
+    });
+    assert.equal(non2xx.outcome, 'invalid_feedback');
+    assert.equal(non2xx.runs[0].reason, 'non_2xx');
+
+    const network = await runBattleL3BrowserTask({
+        proxy: { protocol: 'http', ip: '1.1.1.1', port: 80 },
+        targets: [{ url: 'https://n.test' }],
+        timeoutMs: 50,
+        blockedStatusCodes: [],
+        blockSignals: [],
+        allowedProtocols: ['http'],
+    }, {
+        launchBrowser: createFakeBrowserLauncher([
+            { throwError: new Error('ECONNRESET') },
+        ]),
+    });
+    assert.equal(network.outcome, 'network_error');
+    assert.equal(network.runs[0].outcome, 'network_error');
+    assert.equal(network.runs[0].target, 'https://n.test');
+
+    const protocolNotAllowed = await runBattleL3BrowserTask({
+        proxy: { protocol: 'socks4', ip: '1.1.1.1', port: 80 },
+        targets: [{ name: 't1', url: 'https://x.test' }],
+        allowedProtocols: ['http', 'https'],
+    }, {
+        launchBrowser: createFakeBrowserLauncher([]),
+    });
+    assert.equal(protocolNotAllowed.reason, 'protocol_not_allowed');
+    assert.equal(protocolNotAllowed.outcome, 'invalid_feedback');
+
+    const missingTargets = await runBattleL3BrowserTask({
+        proxy: { protocol: 'http', ip: '1.1.1.1', port: 80 },
+        targets: [],
+    }, {
+        launchBrowser: createFakeBrowserLauncher([]),
+    });
+    assert.equal(missingTargets.reason, 'missing_targets');
+    assert.equal(missingTargets.outcome, 'invalid_feedback');
+
+    const defaultProtocolList = await runBattleL3BrowserTask({
+        proxy: { protocol: 'http', ip: '1.1.1.1', port: 80 },
+        targets: [{ name: 't5', url: 'https://d.test' }],
+        allowedProtocols: null,
+    }, {
+        launchBrowser: createFakeBrowserLauncher([
+            { statusCode: 200, body: 'ly browser content long enough for assert' },
+        ]),
+    });
+    assert.equal(defaultProtocolList.outcome, 'success');
+
+    const closeErrors = await runBattleL3BrowserTask({
+        proxy: { protocol: 'http' },
+        targets: [{ name: 't6', url: 'https://close.test' }],
+        allowedProtocols: [],
+    }, {
+        launchBrowser: async () => ({
+            async newPage() {
+                return {
+                    async goto() {
+                        return { status: () => 200 };
+                    },
+                    async content() {
+                        return 'ly browser content long enough for assert';
+                    },
+                    async close() {
+                        throw new Error('page-close-fail');
+                    },
+                };
+            },
+            async close() {
+                throw new Error('browser-close-fail');
+            },
+        }),
+    });
+    assert.equal(closeErrors.outcome, 'success');
+});
+
+test('battle L3 browser task should cover fallback branch paths', async () => {
+    const protocolNotAllowedNoName = await runBattleL3BrowserTask({
+        proxy: { protocol: 'socks5', ip: '1.1.1.1', port: 80 },
+        targets: [{ url: 'https://guard.test' }],
+        allowedProtocols: ['http', null],
+    }, {
+        launchBrowser: createFakeBrowserLauncher([]),
+    });
+    assert.equal(protocolNotAllowedNoName.reason, 'protocol_not_allowed');
+    assert.equal(protocolNotAllowedNoName.runs[0].target, 'https://guard.test');
+
+    const blockedNoName = await runBattleL3BrowserTask({
+        proxy: { protocol: 'http', ip: '1.1.1.1', port: 80 },
+        targets: [{ url: 'https://blocked.test' }],
+        blockedStatusCodes: [403],
+        allowedProtocols: ['http'],
+    }, {
+        launchBrowser: createFakeBrowserLauncher([
+            { statusCode: 403, body: 'forbidden' },
+        ]),
+    });
+    assert.equal(blockedNoName.runs[0].target, 'https://blocked.test');
+    assert.equal(blockedNoName.runs[0].outcome, 'blocked');
+
+    const non2xxNoName = await runBattleL3BrowserTask({
+        proxy: { protocol: 'http', ip: '1.1.1.1', port: 80 },
+        targets: [{ url: 'https://non2xx.test' }],
+        allowedProtocols: ['http'],
+    }, {
+        launchBrowser: async () => ({
+            async newPage() {
+                return {
+                    async goto() {
+                        return {};
+                    },
+                    async content() {
+                        return 'browser body long enough for non-2xx path';
+                    },
+                    async close() {},
+                };
+            },
+            async close() {},
+        }),
+    });
+    assert.equal(non2xxNoName.runs[0].target, 'https://non2xx.test');
+    assert.equal(non2xxNoName.runs[0].statusCode, 0);
+    assert.equal(non2xxNoName.runs[0].reason, 'non_2xx');
+
+    const contentAssertNoName = await runBattleL3BrowserTask({
+        proxy: { protocol: 'http', ip: '1.1.1.1', port: 80 },
+        targets: [{ url: 'https://content.test' }],
+        allowedProtocols: ['http'],
+    }, {
+        launchBrowser: createFakeBrowserLauncher([
+            { statusCode: 200, body: '' },
+        ]),
+    });
+    assert.equal(contentAssertNoName.runs[0].target, 'https://content.test');
+    assert.equal(contentAssertNoName.runs[0].reason, 'content_assert_failed');
+
+    const successNoName = await runBattleL3BrowserTask({
+        proxy: { ip: '1.1.1.1', port: 80 },
+        targets: [{ url: 'https://success.test' }],
+        allowedProtocols: [],
+    }, {
+        camoufoxModule: createFakeBrowserLauncher([
+            { statusCode: 200, body: 'browser content long enough for success assert' },
+        ]),
+    });
+    assert.equal(successNoName.outcome, 'success');
+    assert.equal(successNoName.runs[0].target, 'https://success.test');
+
+    const browserErrorFallback = await runBattleL3BrowserTask({
+        proxy: { protocol: 'http', ip: '1.1.1.1', port: 80 },
+        targets: [{ url: 'https://error.test' }],
+        allowedProtocols: ['http'],
+    }, {
+        launchBrowser: async () => ({
+            async newPage() {
+                return {
+                    async goto() {
+                        throw {};
+                    },
+                    async close() {},
+                };
+            },
+            async close() {},
+        }),
+    });
+    assert.equal(browserErrorFallback.runs[0].target, 'https://error.test');
+    assert.equal(browserErrorFallback.runs[0].reason, 'browser_error');
+
+    const invalidTargetsType = await runBattleL3BrowserTask({
+        proxy: { protocol: 'http', ip: '1.1.1.1', port: 80 },
+        targets: null,
+        allowedProtocols: ['http'],
+    }, {
+        launchBrowser: createFakeBrowserLauncher([]),
+    });
+    assert.equal(invalidTargetsType.reason, 'missing_targets');
+});
+
 test('stateTransitionTask should return ok', () => {
     assert.deepEqual(stateTransitionTask(), { ok: true });
 });
@@ -669,6 +944,17 @@ test('handleTask should dispatch all task types and throw on unknown type', asyn
         ]),
     });
     assert.equal(l2Result.stage, 'l2');
+
+    const l3Result = await handleTask('battle-l3-browser', {
+        proxy: { protocol: 'http', ip: '1.1.1.1', port: 80 },
+        targets: [{ name: 'ly', url: 'https://www.ly.com' }],
+        allowedProtocols: ['http'],
+    }, {
+        launchBrowser: createFakeBrowserLauncher([
+            { statusCode: 200, body: 'ly browser content long enough for assert' },
+        ]),
+    });
+    assert.equal(l3Result.stage, 'l3');
 
     const transResult = await handleTask('state-transition', {});
     assert.equal(transResult.ok, true);


### PR DESCRIPTION
## Summary
- add L3 browser battle config/env options and candidate selector based on recent L2 success
- add worker task \attle-l3-browser\ with Camoufox launch path and outcome classification
- add engine L3 cycle scheduling/execution and apply L3 branching while scoring with L2 stage weight
- extend config/db/worker/engine tests to cover new L3 behavior and fallback branches

## Validation
- node --test apps/proxy-pool-service/src/worker.test.js apps/proxy-pool-service/src/engine.test.js
- npm run test:proxyhub:coverage

## Coverage Gate
- lines 100%
- functions 100%
- statements 100%
- branches 98.17% (>= 98%)

Closes #70