### PR TITLE
fix(proxyhub-admin): split service branch into dedicated value-board column (#75)

### DIFF
--- a/apps/proxy-pool-service/src/views.test.js
+++ b/apps/proxy-pool-service/src/views.test.js
@@ -18,6 +18,11 @@ test('renderProxyAdminPage should inject refresh interval', () => {
     assert.equal(html.includes('代理明细（前50）'), false);
     assert.equal(html.includes('按价值分从高到低排的名次，1就是当前最有价值的IP。'), true);
     assert.equal(html.includes('系统一共'), true);
+    assert.equal(html.includes("label: '编制'"), true);
+    assert.equal(html.includes("const displayNameWithBranch ="), false);
+    assert.equal(html.includes(" + ' [' + serviceBranch + ']'"), false);
+    assert.equal(html.includes("esc(displayName) + '</td>'"), true);
+    assert.equal(html.includes("esc(serviceBranch) + '</td>'"), true);
 });
 
 test('renderRuntimeLogsPage should return static html', () => {

--- a/apps/proxy-pool-service/src/views/proxy-admin.html
+++ b/apps/proxy-pool-service/src/views/proxy-admin.html
@@ -112,6 +112,7 @@ function getValueBoardHeaders(rankHelp) {
   return [
     { label: '排名', help: '按价值分从高到低排的名次，1就是当前最有价值的IP。' },
     { label: '姓名', help: '这个IP的显示名称，方便在日志和榜单里快速识别。' },
+    { label: '编制', help: '该IP当前所属军种编制，用于体现兵种归属。' },
     { label: '军衔', help: rankHelp },
     { label: '价值分', help: '这是0到100的综合分，分数越高说明这个IP越值得优先使用。' },
     { label: '生命周期', help: '这个IP现在处于哪个阶段（候选/在役/预备/退役），决定它会不会被优先调度。' },
@@ -234,11 +235,11 @@ async function loadAll() {
     const updatedUtc = x.updated_at || '-';
     const displayName = x.display_name || '-';
     const serviceBranch = x.service_branch || '陆军';
-    const displayNameWithBranch = displayName + ' [' + serviceBranch + ']';
     return ''
       + '<tr>'
       + '<td>' + (index + 1) + '</td>'
-      + '<td>' + esc(displayNameWithBranch) + '</td>'
+      + '<td>' + esc(displayName) + '</td>'
+      + '<td>' + esc(serviceBranch) + '</td>'
       + '<td>' + esc(x.rank) + '</td>'
       + '<td class="ok">' + fmtScore(x.ip_value_score) + '</td>'
       + '<td>' + esc(x.lifecycle) + '</td>'


### PR DESCRIPTION
## Summary
- update Proxy Admin value board headers to include a dedicated 编制 column
- remove branch suffix from the 姓名 cell so name text stays clean
- render service_branch in its own column using existing payload field (no API changes)
- add view tests to assert dedicated branch column and no name suffix concatenation

## Validation
- npm run test:proxyhub:unit
- npm run test:proxyhub:coverage

Closes #75