### PR TITLE
feat(proxyhub-admin): add L0-L3 success/fail counters to value board (#76)

### DIFF
--- a/apps/proxy-pool-service/src/db.js
+++ b/apps/proxy-pool-service/src/db.js
@@ -1189,15 +1189,43 @@ class ProxyHubDb {
 
         const where = clauses.length ? `WHERE ${clauses.join(' AND ')}` : '';
         const rows = this.db.prepare(`
-            SELECT id, display_name, ip, port, protocol, source, lifecycle, rank,
-                service_branch,
-                ip_value_score, ip_value_breakdown_json,
-                combat_points, health_score, discipline_score,
-                success_count, total_samples, battle_success_count, battle_fail_count,
-                honor_active_json, retired_type, updated_at
+            SELECT
+                p.id, p.display_name, p.ip, p.port, p.protocol, p.source, p.lifecycle, p.rank,
+                p.service_branch,
+                p.ip_value_score, p.ip_value_breakdown_json,
+                p.combat_points, p.health_score, p.discipline_score,
+                p.success_count, p.total_samples, p.battle_success_count, p.battle_fail_count,
+                p.honor_active_json, p.retired_type, p.updated_at,
+                p.success_count AS l0_success_count,
+                (
+                    p.block_count
+                    + p.timeout_count
+                    + p.network_error_count
+                    + p.invalid_feedback_count
+                ) AS l0_fail_count,
+                COALESCE(stage_stats.l1_success_count, 0) AS l1_success_count,
+                COALESCE(stage_stats.l1_fail_count, 0) AS l1_fail_count,
+                COALESCE(stage_stats.l2_success_count, 0) AS l2_success_count,
+                COALESCE(stage_stats.l2_fail_count, 0) AS l2_fail_count,
+                COALESCE(stage_stats.l3_success_count, 0) AS l3_success_count,
+                COALESCE(stage_stats.l3_fail_count, 0) AS l3_fail_count
             FROM proxies
+            AS p
+            LEFT JOIN (
+                SELECT
+                    proxy_id,
+                    SUM(CASE WHEN stage = 'l1' AND outcome = 'success' THEN 1 ELSE 0 END) AS l1_success_count,
+                    SUM(CASE WHEN stage = 'l1' AND outcome IN ('blocked', 'timeout', 'network_error', 'invalid_feedback') THEN 1 ELSE 0 END) AS l1_fail_count,
+                    SUM(CASE WHEN stage = 'l2' AND outcome = 'success' THEN 1 ELSE 0 END) AS l2_success_count,
+                    SUM(CASE WHEN stage = 'l2' AND outcome IN ('blocked', 'timeout', 'network_error', 'invalid_feedback') THEN 1 ELSE 0 END) AS l2_fail_count,
+                    SUM(CASE WHEN stage = 'l3' AND outcome = 'success' THEN 1 ELSE 0 END) AS l3_success_count,
+                    SUM(CASE WHEN stage = 'l3' AND outcome IN ('blocked', 'timeout', 'network_error', 'invalid_feedback') THEN 1 ELSE 0 END) AS l3_fail_count
+                FROM battle_test_runs
+                GROUP BY proxy_id
+            ) AS stage_stats
+            ON stage_stats.proxy_id = p.id
             ${where}
-            ORDER BY ip_value_score DESC, combat_points DESC, updated_at DESC
+            ORDER BY p.ip_value_score DESC, p.combat_points DESC, p.updated_at DESC
             LIMIT @limit
         `).all(params);
 

--- a/apps/proxy-pool-service/src/db.test.js
+++ b/apps/proxy-pool-service/src/db.test.js
@@ -537,6 +537,10 @@ test('value board API should sort by value and parse breakdown and honor fields'
         ip_value_breakdown_json: JSON.stringify({ grade: 'A' }),
         honor_active_json: JSON.stringify(['钢铁连胜']),
         success_count: 8,
+        block_count: 1,
+        timeout_count: 2,
+        network_error_count: 3,
+        invalid_feedback_count: 4,
         total_samples: 10,
         battle_success_count: 3,
         battle_fail_count: 1,
@@ -550,6 +554,73 @@ test('value board API should sort by value and parse breakdown and honor fields'
         updated_at: now,
     });
 
+    h.db.insertBattleTestRun({
+        timestamp: now,
+        proxy_id: all[0].id,
+        stage: 'l1',
+        target: 'l1-a',
+        outcome: 'success',
+        status_code: 200,
+        latency_ms: 20,
+        reason: 'ok',
+        details: {},
+    });
+    h.db.insertBattleTestRun({
+        timestamp: now,
+        proxy_id: all[0].id,
+        stage: 'l1',
+        target: 'l1-b',
+        outcome: 'blocked',
+        status_code: 403,
+        latency_ms: 30,
+        reason: 'blocked',
+        details: {},
+    });
+    h.db.insertBattleTestRun({
+        timestamp: now,
+        proxy_id: all[0].id,
+        stage: 'l1',
+        target: 'l1-c',
+        outcome: 'timeout',
+        status_code: null,
+        latency_ms: 35,
+        reason: 'timeout',
+        details: {},
+    });
+    h.db.insertBattleTestRun({
+        timestamp: now,
+        proxy_id: all[0].id,
+        stage: 'l2',
+        target: 'l2-a',
+        outcome: 'success',
+        status_code: 200,
+        latency_ms: 40,
+        reason: 'ok',
+        details: {},
+    });
+    h.db.insertBattleTestRun({
+        timestamp: now,
+        proxy_id: all[0].id,
+        stage: 'l2',
+        target: 'l2-b',
+        outcome: 'invalid_feedback',
+        status_code: 200,
+        latency_ms: 45,
+        reason: 'bad',
+        details: {},
+    });
+    h.db.insertBattleTestRun({
+        timestamp: now,
+        proxy_id: all[0].id,
+        stage: 'l3',
+        target: 'l3-a',
+        outcome: 'network_error',
+        status_code: null,
+        latency_ms: 50,
+        reason: 'err',
+        details: {},
+    });
+
     const board = h.db.getValueBoard(10);
     assert.equal(board.length, 2);
     assert.equal(board[0].ip_value_score >= board[1].ip_value_score, true);
@@ -558,6 +629,22 @@ test('value board API should sort by value and parse breakdown and honor fields'
     assert.deepEqual(board[1].honor_active, []);
     assert.equal(board[0].success_ratio, 0.8);
     assert.equal(board[0].battle_ratio, 0.75);
+    assert.equal(board[0].l0_success_count, 8);
+    assert.equal(board[0].l0_fail_count, 10);
+    assert.equal(board[0].l1_success_count, 1);
+    assert.equal(board[0].l1_fail_count, 2);
+    assert.equal(board[0].l2_success_count, 1);
+    assert.equal(board[0].l2_fail_count, 1);
+    assert.equal(board[0].l3_success_count, 0);
+    assert.equal(board[0].l3_fail_count, 1);
+    assert.equal(board[1].l0_success_count, 0);
+    assert.equal(board[1].l0_fail_count, 0);
+    assert.equal(board[1].l1_success_count, 0);
+    assert.equal(board[1].l1_fail_count, 0);
+    assert.equal(board[1].l2_success_count, 0);
+    assert.equal(board[1].l2_fail_count, 0);
+    assert.equal(board[1].l3_success_count, 0);
+    assert.equal(board[1].l3_fail_count, 0);
 
     const filtered = h.db.getValueBoard(10, 'active');
     assert.equal(filtered.length, 1);

--- a/apps/proxy-pool-service/src/server.test.js
+++ b/apps/proxy-pool-service/src/server.test.js
@@ -131,7 +131,19 @@ function createStubs() {
         getProxyList: () => [{ id: 1 }],
         getEvents: () => [{ id: 2 }],
         getBattleTestRuns: () => [{ id: 6, stage: 'l1' }],
-        getValueBoard: () => [{ id: 7, ip_value_score: 88.8, service_branch: '陆军' }],
+        getValueBoard: () => [{
+            id: 7,
+            ip_value_score: 88.8,
+            service_branch: '陆军',
+            l0_success_count: 9,
+            l0_fail_count: 1,
+            l1_success_count: 4,
+            l1_fail_count: 2,
+            l2_success_count: 3,
+            l2_fail_count: 1,
+            l3_success_count: 2,
+            l3_fail_count: 1,
+        }],
         getRankBoard: () => [{ rank: '新兵', count: 1 }],
         getServiceBranchDistribution: () => [{ service_branch: '陆军', count: 1 }],
         getRecruitCampBoard: () => [
@@ -284,6 +296,18 @@ test('server runtime should expose all REST endpoints and shutdown cleanly', asy
         const res = await fetch(baseUrl + p, { signal: AbortSignal.timeout(10000) });
         assert.equal(res.status, 200);
     }
+
+    const valueBoardRes = await fetch(baseUrl + '/v1/proxies/value-board?limit=20');
+    const valueBoardPayload = await valueBoardRes.json();
+    assert.equal(valueBoardPayload.items.length > 0, true);
+    assert.equal(typeof valueBoardPayload.items[0].l0_success_count, 'number');
+    assert.equal(typeof valueBoardPayload.items[0].l0_fail_count, 'number');
+    assert.equal(typeof valueBoardPayload.items[0].l1_success_count, 'number');
+    assert.equal(typeof valueBoardPayload.items[0].l1_fail_count, 'number');
+    assert.equal(typeof valueBoardPayload.items[0].l2_success_count, 'number');
+    assert.equal(typeof valueBoardPayload.items[0].l2_fail_count, 'number');
+    assert.equal(typeof valueBoardPayload.items[0].l3_success_count, 'number');
+    assert.equal(typeof valueBoardPayload.items[0].l3_fail_count, 'number');
 
     const patchOk = await fetch(baseUrl + '/v1/proxies/policy', {
         method: 'POST',

--- a/apps/proxy-pool-service/src/views.test.js
+++ b/apps/proxy-pool-service/src/views.test.js
@@ -18,6 +18,14 @@ test('renderProxyAdminPage should inject refresh interval', () => {
     assert.equal(html.includes('代理明细（前50）'), false);
     assert.equal(html.includes('按价值分从高到低排的名次，1就是当前最有价值的IP。'), true);
     assert.equal(html.includes('系统一共'), true);
+    assert.equal(html.includes("label: 'L0(成功/失败)'"), true);
+    assert.equal(html.includes("label: 'L1(成功/失败)'"), true);
+    assert.equal(html.includes("label: 'L2(成功/失败)'"), true);
+    assert.equal(html.includes("label: 'L3(成功/失败)'"), true);
+    assert.equal(html.includes("fmt(x.l0_success_count) + '/' + fmt(x.l0_fail_count)"), true);
+    assert.equal(html.includes("fmt(x.l1_success_count) + '/' + fmt(x.l1_fail_count)"), true);
+    assert.equal(html.includes("fmt(x.l2_success_count) + '/' + fmt(x.l2_fail_count)"), true);
+    assert.equal(html.includes("fmt(x.l3_success_count) + '/' + fmt(x.l3_fail_count)"), true);
 });
 
 test('renderRuntimeLogsPage should return static html', () => {

--- a/apps/proxy-pool-service/src/views/proxy-admin.html
+++ b/apps/proxy-pool-service/src/views/proxy-admin.html
@@ -117,6 +117,10 @@ function getValueBoardHeaders(rankHelp) {
     { label: '生命周期', help: '这个IP现在处于哪个阶段（候选/在役/预备/退役），决定它会不会被优先调度。' },
     { label: '成功率', help: '历史成功次数除以总样本数，反映总体能不能跑通。' },
     { label: '战场胜率', help: '战场测试里成功次数除以战场总次数，反映真实战场好不好用。' },
+    { label: 'L0(成功/失败)', help: 'L0层的累计成功/失败次数，失败包含 blocked、timeout、network_error、invalid_feedback。' },
+    { label: 'L1(成功/失败)', help: 'L1战场测试的累计成功/失败次数。' },
+    { label: 'L2(成功/失败)', help: 'L2战场测试的累计成功/失败次数。' },
+    { label: 'L3(成功/失败)', help: 'L3战场测试的累计成功/失败次数。' },
     { label: '激活荣誉', help: '当前生效中的荣誉标签，代表这个IP最近在某些维度表现突出。' },
     { label: '地址', help: 'IP、端口和协议组合地址，排障和复现问题时最直接。' },
     { label: '来源', help: '这个IP来自哪个抓取源，可用来判断源质量。' },
@@ -244,6 +248,10 @@ async function loadAll() {
       + '<td>' + esc(x.lifecycle) + '</td>'
       + '<td>' + fmtPercent(x.success_ratio) + '</td>'
       + '<td>' + fmtPercent(x.battle_ratio) + '</td>'
+      + '<td class="mono">' + fmt(x.l0_success_count) + '/' + fmt(x.l0_fail_count) + '</td>'
+      + '<td class="mono">' + fmt(x.l1_success_count) + '/' + fmt(x.l1_fail_count) + '</td>'
+      + '<td class="mono">' + fmt(x.l2_success_count) + '/' + fmt(x.l2_fail_count) + '</td>'
+      + '<td class="mono">' + fmt(x.l3_success_count) + '/' + fmt(x.l3_fail_count) + '</td>'
       + '<td>' + esc(honorText) + '</td>'
       + '<td class="mono">' + esc(address) + '</td>'
       + '<td>' + esc(x.source) + '</td>'


### PR DESCRIPTION
## Summary
- extend value-board DB query with stage-level success/fail counters for L1/L2/L3 from attle_test_runs
- expose L0 success/fail counters on value-board rows from existing validation counters (success_count and fail-category counts)
- keep existing value-board sorting and filters unchanged (ip_value_score primary, lifecycle/serviceBranch/excludeRetired behavior unchanged)
- render four new grouped columns in /proxy-admin value board:
  - L0(成功/失败)
  - L1(成功/失败)
  - L2(成功/失败)
  - L3(成功/失败)
- add DB/API/view tests for field presence, aggregation correctness, and zero-default behavior

## Validation
- 
ode --test apps/proxy-pool-service/src/db.test.js apps/proxy-pool-service/src/server.test.js apps/proxy-pool-service/src/views.test.js
- 
pm run test:proxyhub:unit
- 
pm run test:proxyhub:coverage

## Coverage
- lines/functions/statements: 100%
- branches: 98.17% (>= 98% threshold)

Closes #76