### PR TITLE
feat(proxyhub): #77 籍贯悬停原文 + 可扩展兵种

### DIFF
--- a/apps/proxy-pool-service/src/config.js
+++ b/apps/proxy-pool-service/src/config.js
@@ -25,6 +25,18 @@ function parseJsonArrayEnv(value, fallback) {
     }
 }
 
+// 0280_parseCsvListEnv_解析CSV列表环境变量逻辑
+function parseCsvListEnv(value, fallback = []) {
+    if (value == null || String(value).trim() === '') {
+        return deepClone(fallback);
+    }
+    const parsed = String(value)
+        .split(',')
+        .map((item) => String(item || '').trim())
+        .filter((item, index, list) => item.length > 0 && list.indexOf(item) === index);
+    return parsed.length > 0 ? parsed : deepClone(fallback);
+}
+
 const legacyRanks = [
     { rank: '新兵', minHours: 0, minPoints: 0, minSamples: 0 },
     { rank: '列兵', minHours: 12, minPoints: 80, minSamples: 20 },
@@ -319,6 +331,10 @@ const resolvedBranchingRules = parseJsonArrayEnv(
     process.env.PROXY_HUB_BRANCHING_RULES_JSON,
     defaultBranchingRules,
 );
+const resolvedNativeTargetBranches = parseCsvListEnv(
+    process.env.PROXY_HUB_NATIVE_TARGET_BRANCHES,
+    ['海军', '海豹突击队'],
+);
 
 const sourceProfiles = {
     speedx_bundle: {
@@ -534,6 +550,12 @@ module.exports = {
         failStreakField: 'branch_fail_streak',
         defaultBranch: String(process.env.PROXY_HUB_BRANCHING_DEFAULT || '陆军'),
         rules: deepClone(resolvedBranchingRules),
+    },
+    native: {
+        enabled: toBool(process.env.PROXY_HUB_NATIVE_ENABLED, true),
+        timeoutMs: Number(process.env.PROXY_HUB_NATIVE_TIMEOUT_MS || 3000),
+        retryHours: Number(process.env.PROXY_HUB_NATIVE_RETRY_HOURS || 1),
+        targetBranches: deepClone(resolvedNativeTargetBranches),
     },
     policyProfiles: deepClone(policyProfiles),
     policy: deepClone(policyProfiles[activeProfile]),

--- a/apps/proxy-pool-service/src/config.test.js
+++ b/apps/proxy-pool-service/src/config.test.js
@@ -46,6 +46,10 @@ function loadConfigWithEnv(overrides = {}) {
         'PROXY_HUB_BRANCHING_ENABLED',
         'PROXY_HUB_BRANCHING_DEFAULT',
         'PROXY_HUB_BRANCHING_RULES_JSON',
+        'PROXY_HUB_NATIVE_ENABLED',
+        'PROXY_HUB_NATIVE_TIMEOUT_MS',
+        'PROXY_HUB_NATIVE_RETRY_HOURS',
+        'PROXY_HUB_NATIVE_TARGET_BRANCHES',
         'PROXY_HUB_DB_PATH',
         ...Object.keys(overrides),
     ]);
@@ -111,6 +115,10 @@ test('config should expose required default values', { concurrency: false }, () 
     assert.equal(Array.isArray(config.battle.targets.l1), true);
     assert.equal(config.battle.targets.l2Primary[0].name, 'ly-flight-main');
     assert.equal(config.battle.targets.l2Primary[0].url, 'https://www.ly.com/flights/home');
+    assert.equal(config.native.enabled, true);
+    assert.equal(config.native.timeoutMs, 3000);
+    assert.equal(config.native.retryHours, 1);
+    assert.deepEqual(config.native.targetBranches, ['海军', '海豹突击队']);
 });
 
 test('config ranks should be ordered and complete', { concurrency: false }, () => {
@@ -246,6 +254,28 @@ test('config should fallback branching rules when env json is not an array', { c
 
     assert.equal(Array.isArray(config.branching.rules), true);
     assert.equal(config.branching.rules.length >= 4, true);
+});
+
+test('config should support native lookup env overrides', { concurrency: false }, () => {
+    const config = loadConfigWithEnv({
+        PROXY_HUB_NATIVE_ENABLED: 'false',
+        PROXY_HUB_NATIVE_TIMEOUT_MS: '4321',
+        PROXY_HUB_NATIVE_RETRY_HOURS: '2',
+        PROXY_HUB_NATIVE_TARGET_BRANCHES: '海军,海豹突击队,空军,海军',
+    });
+
+    assert.equal(config.native.enabled, false);
+    assert.equal(config.native.timeoutMs, 4321);
+    assert.equal(config.native.retryHours, 2);
+    assert.deepEqual(config.native.targetBranches, ['海军', '海豹突击队', '空军']);
+});
+
+test('config should fallback native target branches when csv env is empty after normalization', { concurrency: false }, () => {
+    const config = loadConfigWithEnv({
+        PROXY_HUB_NATIVE_TARGET_BRANCHES: ',, ,',
+    });
+
+    assert.deepEqual(config.native.targetBranches, ['海军', '海豹突击队']);
 });
 
 test('config should prioritize explicit PROXY_HUB_DB_PATH over profile db mapping', { concurrency: false }, () => {

--- a/apps/proxy-pool-service/src/db.js
+++ b/apps/proxy-pool-service/src/db.js
@@ -66,6 +66,14 @@ class ProxyHubDb {
                 rank TEXT NOT NULL DEFAULT '新兵',
                 service_branch TEXT NOT NULL DEFAULT '陆军',
                 branch_fail_streak INTEGER NOT NULL DEFAULT 0,
+                native_place TEXT NOT NULL DEFAULT '未知',
+                native_country TEXT,
+                native_city TEXT,
+                native_provider TEXT,
+                native_resolved_at TEXT,
+                native_lookup_status TEXT NOT NULL DEFAULT 'pending',
+                native_next_retry_at TEXT,
+                native_lookup_raw_json TEXT,
                 service_hours REAL NOT NULL DEFAULT 0,
                 rank_service_hours REAL NOT NULL DEFAULT 0,
                 combat_points INTEGER NOT NULL DEFAULT 0,
@@ -317,6 +325,14 @@ class ProxyHubDb {
             { name: 'backoff_reason', sql: 'TEXT' },
             { name: 'service_branch', sql: "TEXT NOT NULL DEFAULT '陆军'" },
             { name: 'branch_fail_streak', sql: 'INTEGER NOT NULL DEFAULT 0' },
+            { name: 'native_place', sql: "TEXT NOT NULL DEFAULT '未知'" },
+            { name: 'native_country', sql: 'TEXT' },
+            { name: 'native_city', sql: 'TEXT' },
+            { name: 'native_provider', sql: 'TEXT' },
+            { name: 'native_resolved_at', sql: 'TEXT' },
+            { name: 'native_lookup_status', sql: "TEXT NOT NULL DEFAULT 'pending'" },
+            { name: 'native_next_retry_at', sql: 'TEXT' },
+            { name: 'native_lookup_raw_json', sql: 'TEXT' },
         ];
 
         for (const column of requiredColumns) {
@@ -1130,6 +1146,8 @@ class ProxyHubDb {
         return this.db.prepare(`
             SELECT id, display_name, ip, port, protocol, source, lifecycle, rank,
                 service_branch, branch_fail_streak,
+                native_place, native_country, native_city, native_provider, native_resolved_at,
+                native_lookup_status, native_next_retry_at, native_lookup_raw_json,
                 service_hours, rank_service_hours, combat_points, health_score, discipline_score,
                 success_count, block_count, timeout_count, network_error_count,
                 total_samples, retired_type, is_applied, updated_at, last_checked_at,
@@ -1192,6 +1210,9 @@ class ProxyHubDb {
             SELECT
                 p.id, p.display_name, p.ip, p.port, p.protocol, p.source, p.lifecycle, p.rank,
                 p.service_branch,
+                p.native_place, p.native_country, p.native_city, p.native_provider,
+                p.native_resolved_at, p.native_lookup_status, p.native_next_retry_at,
+                p.native_lookup_raw_json,
                 p.ip_value_score, p.ip_value_breakdown_json,
                 p.combat_points, p.health_score, p.discipline_score,
                 p.success_count, p.total_samples, p.battle_success_count, p.battle_fail_count,

--- a/apps/proxy-pool-service/src/db.test.js
+++ b/apps/proxy-pool-service/src/db.test.js
@@ -262,8 +262,13 @@ test('query list APIs should support filters and distributions', () => {
     assert.equal(Object.prototype.hasOwnProperty.call(all[0], 'ip_value_score'), true);
     assert.equal(Object.prototype.hasOwnProperty.call(all[0], 'service_branch'), true);
     assert.equal(Object.prototype.hasOwnProperty.call(all[0], 'branch_fail_streak'), true);
+    assert.equal(Object.prototype.hasOwnProperty.call(all[0], 'native_place'), true);
+    assert.equal(Object.prototype.hasOwnProperty.call(all[0], 'native_lookup_status'), true);
+    assert.equal(Object.prototype.hasOwnProperty.call(all[0], 'native_lookup_raw_json'), true);
     assert.equal(all[0].service_branch, '陆军');
     assert.equal(all[0].branch_fail_streak, 0);
+    assert.equal(all[0].native_place, '未知');
+    assert.equal(all[0].native_lookup_status, 'pending');
 
     h.db.updateProxyById(all[0].id, {
         rank: '士官',
@@ -551,6 +556,12 @@ test('value board API should sort by value and parse breakdown and honor fields'
         ip_value_score: 40,
         ip_value_breakdown_json: '[]',
         honor_active_json: '',
+        native_place: '中国-北京',
+        native_country: '中国',
+        native_city: '北京',
+        native_provider: 'ip-api',
+        native_lookup_status: 'resolved',
+        native_lookup_raw_json: '{"status":"success","country":"中国","city":"北京"}',
         updated_at: now,
     });
 
@@ -637,6 +648,8 @@ test('value board API should sort by value and parse breakdown and honor fields'
     assert.equal(board[0].l2_fail_count, 1);
     assert.equal(board[0].l3_success_count, 0);
     assert.equal(board[0].l3_fail_count, 1);
+    assert.equal(board[0].native_place, '未知');
+    assert.equal(board[0].native_lookup_status, 'pending');
     assert.equal(board[1].l0_success_count, 0);
     assert.equal(board[1].l0_fail_count, 0);
     assert.equal(board[1].l1_success_count, 0);
@@ -645,6 +658,9 @@ test('value board API should sort by value and parse breakdown and honor fields'
     assert.equal(board[1].l2_fail_count, 0);
     assert.equal(board[1].l3_success_count, 0);
     assert.equal(board[1].l3_fail_count, 0);
+    assert.equal(board[1].native_place, '中国-北京');
+    assert.equal(board[1].native_lookup_status, 'resolved');
+    assert.equal(board[1].native_lookup_raw_json.includes('"country":"中国"'), true);
 
     const filtered = h.db.getValueBoard(10, 'active');
     assert.equal(filtered.length, 1);

--- a/apps/proxy-pool-service/src/engine.js
+++ b/apps/proxy-pool-service/src/engine.js
@@ -406,6 +406,52 @@ function resolveBranchingTransition({
     return { updates, events };
 }
 
+// 0281_createAbortSignal_创建中止信号逻辑
+function createAbortSignal(timeoutMs) {
+    if (typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function') {
+        return AbortSignal.timeout(timeoutMs);
+    }
+    return undefined;
+}
+
+// 0282_readNativeLookupConfig_读取籍贯解析配置逻辑
+function readNativeLookupConfig(config = {}) {
+    const raw = config.native || {};
+    const targetBranches = Array.isArray(raw.targetBranches)
+        ? raw.targetBranches
+            .map((item) => String(item || '').trim())
+            .filter((item, index, list) => item.length > 0 && list.indexOf(item) === index)
+        : ['海军', '海豹突击队'];
+    return {
+        enabled: raw.enabled === true,
+        timeoutMs: Math.max(500, Number(raw.timeoutMs) || 3000),
+        retryHours: Math.max(1, Number(raw.retryHours) || 1),
+        targetBranches: targetBranches.length > 0 ? targetBranches : ['海军', '海豹突击队'],
+    };
+}
+
+// 0283_isNativeRetryDue_判断籍贯重试窗口逻辑
+function isNativeRetryDue(nextRetryAt, nowIso) {
+    if (!nextRetryAt) {
+        return true;
+    }
+    const nextMs = Date.parse(nextRetryAt);
+    if (!Number.isFinite(nextMs)) {
+        return true;
+    }
+    const nowMs = Date.parse(nowIso);
+    return Number.isFinite(nowMs) ? nextMs <= nowMs : nextMs <= Date.now();
+}
+
+// 0284_normalizeNativeLookupStatus_规范化籍贯状态逻辑
+function normalizeNativeLookupStatus(status) {
+    const text = String(status || '').trim().toLowerCase();
+    if (['pending', 'resolved', 'failed', 'skipped'].includes(text)) {
+        return text;
+    }
+    return 'pending';
+}
+
 class ProxyHubEngine extends EventEmitter {
     // 0027_constructor_初始化实例逻辑
     constructor({ config, db, workerPool, logger, now }) {
@@ -432,6 +478,7 @@ class ProxyHubEngine extends EventEmitter {
         this.isBattleL3Running = false;
         this.isCandidateSweepRunning = false;
         this.threadPoolAlerting = false;
+        this.nativeLookupInFlight = new Set();
     }
 
     // 0210_isBattleEnabled_判断战场测试开关逻辑
@@ -442,6 +489,280 @@ class ProxyHubEngine extends EventEmitter {
     // 0278_isBattleL3Enabled_判断战场L3开关逻辑
     isBattleL3Enabled() {
         return this.isBattleEnabled() && this.config?.battle?.l3?.enabled === true;
+    }
+
+    // 0285_resolveNativeLookupDecision_解析籍贯查询决策逻辑
+    resolveNativeLookupDecision(proxy, nowIso = new Date().toISOString()) {
+        const policy = readNativeLookupConfig(this.config);
+        if (!policy.enabled) {
+            return { action: 'none', reason: 'native-disabled', policy };
+        }
+        if (!proxy || !proxy.id) {
+            return { action: 'none', reason: 'proxy-missing', policy };
+        }
+
+        const branch = String(proxy.service_branch || '').trim();
+        const isTargetBranch = policy.targetBranches.includes(branch);
+        const status = normalizeNativeLookupStatus(proxy.native_lookup_status);
+        if (!isTargetBranch) {
+            if (status === 'pending') {
+                return { action: 'skip', reason: 'branch-not-target', policy };
+            }
+            return { action: 'none', reason: 'branch-not-target', policy };
+        }
+
+        const nativePlace = String(proxy.native_place || '未知').trim() || '未知';
+        if (nativePlace !== '未知') {
+            return { action: 'none', reason: 'native-already-known', policy };
+        }
+        if (!isNativeRetryDue(proxy.native_next_retry_at, nowIso)) {
+            return { action: 'none', reason: 'retry-not-due', policy };
+        }
+
+        return { action: 'lookup', reason: 'eligible', policy };
+    }
+
+    // 0286_markNativeLookupSkipped_标记籍贯跳过逻辑
+    markNativeLookupSkipped(proxy, sourceName, nowIso, reason = 'branch-not-target') {
+        this.db.updateProxyById(proxy.id, {
+            native_lookup_status: 'skipped',
+            updated_at: nowIso,
+        });
+        const updatedProxy = this.db.getProxyById(proxy.id) || proxy;
+        this.db.insertProxyEvent({
+            timestamp: nowIso,
+            proxy_id: proxy.id,
+            display_name: updatedProxy.display_name,
+            event_type: 'native_lookup_skipped',
+            level: EVENT_LEVEL.INFO,
+            message: `籍贯解析跳过：${updatedProxy.display_name}`,
+            details: {
+                ip: updatedProxy.ip,
+                service_branch: updatedProxy.service_branch,
+                provider: 'ip-api',
+                status: 'skipped',
+                reason,
+            },
+        });
+        this.logger.write({
+            event: '籍贯解析跳过',
+            proxyName: updatedProxy.display_name,
+            ipSource: sourceName,
+            stage: '籍贯',
+            result: '跳过',
+            reason,
+            action: '非目标兵种，不触发查询',
+            details: {
+                ip: updatedProxy.ip,
+                service_branch: updatedProxy.service_branch,
+                provider: 'ip-api',
+                status: 'skipped',
+                reason,
+            },
+        });
+    }
+
+    // 0287_resolveNativePlaceByIp_解析IP籍贯逻辑
+    async resolveNativePlaceByIp(ip, timeoutMs = 3000) {
+        if (typeof fetch !== 'function') {
+            throw new Error('ip-api-fetch-unavailable');
+        }
+
+        const safeIp = String(ip || '').trim();
+        if (safeIp.length === 0) {
+            throw new Error('ip-api-ip-missing');
+        }
+
+        const response = await fetch(`http://ip-api.com/json/${encodeURIComponent(safeIp)}?lang=zh-CN`, {
+            signal: createAbortSignal(Math.max(500, Number(timeoutMs) || 3000)),
+            headers: {
+                'user-agent': 'ProxyHub/1.0',
+                accept: 'application/json',
+            },
+        });
+        if (!response.ok) {
+            throw new Error(`ip-api-http-${response.status}`);
+        }
+
+        const rawJson = await response.text();
+        let payload;
+        try {
+            payload = JSON.parse(rawJson);
+        } catch {
+            throw new Error('ip-api-invalid-json');
+        }
+
+        if (String(payload?.status || '').toLowerCase() !== 'success') {
+            const reason = String(payload?.message || 'request-failed').trim();
+            throw new Error(`ip-api-${reason}`);
+        }
+
+        const country = String(payload?.country || '').trim() || '未知';
+        const city = String(payload?.city || '').trim() || '未知';
+        return {
+            provider: 'ip-api',
+            country,
+            city,
+            place: `${country}-${city}`,
+            rawJson: rawJson || JSON.stringify(payload),
+        };
+    }
+
+    // 0288_runNativeLookupTask_执行籍贯补全任务逻辑
+    async runNativeLookupTask(proxyId, sourceName) {
+        const startedAtIso = this.now().toISOString();
+        const proxy = this.db.getProxyById(proxyId);
+        if (!proxy) {
+            return;
+        }
+
+        const decision = this.resolveNativeLookupDecision(proxy, startedAtIso);
+        if (decision.action === 'skip') {
+            this.markNativeLookupSkipped(proxy, sourceName, startedAtIso, decision.reason);
+            return;
+        }
+        if (decision.action !== 'lookup') {
+            return;
+        }
+
+        try {
+            const resolved = await this.resolveNativePlaceByIp(proxy.ip, decision.policy.timeoutMs);
+            const nowIso = this.now().toISOString();
+            const latestProxy = this.db.getProxyById(proxyId) || proxy;
+            const latestDecision = this.resolveNativeLookupDecision(latestProxy, nowIso);
+            if (latestDecision.action !== 'lookup') {
+                return;
+            }
+            this.db.updateProxyById(proxyId, {
+                native_country: resolved.country,
+                native_city: resolved.city,
+                native_place: resolved.place,
+                native_provider: resolved.provider,
+                native_resolved_at: nowIso,
+                native_lookup_status: 'resolved',
+                native_next_retry_at: null,
+                native_lookup_raw_json: resolved.rawJson,
+                updated_at: nowIso,
+            });
+            const updatedProxy = this.db.getProxyById(proxyId) || proxy;
+            this.db.insertProxyEvent({
+                timestamp: nowIso,
+                proxy_id: proxyId,
+                display_name: updatedProxy.display_name,
+                event_type: 'native_lookup_resolved',
+                level: EVENT_LEVEL.INFO,
+                message: `籍贯解析成功：${updatedProxy.display_name} -> ${resolved.place}`,
+                details: {
+                    ip: updatedProxy.ip,
+                    service_branch: updatedProxy.service_branch,
+                    provider: resolved.provider,
+                    status: 'resolved',
+                    reason: 'ip-api-success',
+                },
+            });
+            this.logger.write({
+                event: '籍贯解析成功',
+                proxyName: updatedProxy.display_name,
+                ipSource: sourceName,
+                stage: '籍贯',
+                result: resolved.place,
+                action: '已写入籍贯',
+                details: {
+                    ip: updatedProxy.ip,
+                    service_branch: updatedProxy.service_branch,
+                    provider: resolved.provider,
+                    status: 'resolved',
+                },
+            });
+        } catch (error) {
+            const nowIso = this.now().toISOString();
+            const latestProxy = this.db.getProxyById(proxyId) || proxy;
+            const latestDecision = this.resolveNativeLookupDecision(latestProxy, nowIso);
+            if (latestDecision.action !== 'lookup') {
+                return;
+            }
+            const retryMs = Math.round((decision.policy.retryHours || 1) * 3_600_000);
+            const retryAt = new Date(Date.parse(nowIso) + retryMs).toISOString();
+            const reason = error?.message || 'native-lookup-failed';
+            this.db.updateProxyById(proxyId, {
+                native_lookup_status: 'failed',
+                native_next_retry_at: retryAt,
+                updated_at: nowIso,
+            });
+            const updatedProxy = this.db.getProxyById(proxyId) || proxy;
+            this.db.insertProxyEvent({
+                timestamp: nowIso,
+                proxy_id: proxyId,
+                display_name: updatedProxy.display_name,
+                event_type: 'native_lookup_failed',
+                level: EVENT_LEVEL.INFO,
+                message: `籍贯解析失败：${updatedProxy.display_name}`,
+                details: {
+                    ip: updatedProxy.ip,
+                    service_branch: updatedProxy.service_branch,
+                    provider: 'ip-api',
+                    status: 'failed',
+                    reason,
+                    retryAt,
+                },
+            });
+            this.logger.write({
+                event: '籍贯解析失败',
+                proxyName: updatedProxy.display_name,
+                ipSource: sourceName,
+                stage: '籍贯',
+                result: '失败',
+                reason,
+                action: `等待重试至 ${retryAt}`,
+                details: {
+                    ip: updatedProxy.ip,
+                    service_branch: updatedProxy.service_branch,
+                    provider: 'ip-api',
+                    status: 'failed',
+                    reason,
+                    retryAt,
+                },
+            });
+        }
+    }
+
+    // 0289_scheduleNativeLookup_调度籍贯补全逻辑
+    scheduleNativeLookup(proxy, sourceName, nowIso) {
+        const decision = this.resolveNativeLookupDecision(proxy, nowIso);
+        if (decision.action === 'skip') {
+            this.markNativeLookupSkipped(proxy, sourceName, nowIso, decision.reason);
+            return;
+        }
+        if (decision.action !== 'lookup') {
+            return;
+        }
+        if (this.nativeLookupInFlight.has(proxy.id)) {
+            return;
+        }
+
+        this.nativeLookupInFlight.add(proxy.id);
+        const task = this.runNativeLookupTask(proxy.id, sourceName)
+            .catch((error) => {
+                this.logger.write({
+                    event: '籍贯解析失败',
+                    proxyName: proxy.display_name,
+                    ipSource: sourceName,
+                    stage: '籍贯',
+                    result: '异常',
+                    reason: error?.message || 'native-lookup-task-failed',
+                    action: '忽略异常，等待下一轮',
+                    details: {
+                        ip: proxy.ip,
+                        service_branch: proxy.service_branch,
+                        provider: 'ip-api',
+                        status: 'failed',
+                    },
+                });
+            })
+            .finally(() => {
+                this.nativeLookupInFlight.delete(proxy.id);
+            });
+        task.catch(() => {});
     }
 
     // 0028_start_启动逻辑
@@ -876,6 +1197,8 @@ class ProxyHubEngine extends EventEmitter {
                 details: event.details,
             });
         }
+
+        this.scheduleNativeLookup(updatedProxy, sourceName, nowIso);
 
         const activeHonors = parseArrayJson(updatedProxy.honor_active_json);
 
@@ -1501,6 +1824,9 @@ module.exports = {
     resolveSourceFeeds,
     readBranchingConfig,
     resolveBranchingTransition,
+    readNativeLookupConfig,
+    isNativeRetryDue,
+    normalizeNativeLookupStatus,
     ProxyHubEngine,
 };
 

--- a/apps/proxy-pool-service/src/engine.test.js
+++ b/apps/proxy-pool-service/src/engine.test.js
@@ -18,6 +18,9 @@ const {
     resolveSourceFeeds,
     readBranchingConfig,
     resolveBranchingTransition,
+    readNativeLookupConfig,
+    isNativeRetryDue,
+    normalizeNativeLookupStatus,
     ProxyHubEngine,
 } = require('./engine');
 
@@ -72,6 +75,12 @@ function createConfig(dbPath) {
             l2BaseMs: 900000,
             multiplier: 2,
             maxMs: 3600000,
+        },
+        native: {
+            enabled: false,
+            timeoutMs: 3000,
+            retryHours: 1,
+            targetBranches: ['海军', '海豹突击队'],
         },
         validation: { allowedProtocols: ['http', 'https', 'socks4', 'socks5'], maxTimeoutMs: 1000 },
         policy: {
@@ -145,6 +154,18 @@ function cleanupDb(h) {
     fs.rmSync(h.dir, { recursive: true, force: true });
 }
 
+// 0041_waitFor_等待条件成立逻辑
+async function waitFor(check, timeoutMs = 2000) {
+    const started = Date.now();
+    while (Date.now() - started < timeoutMs) {
+        if (check()) {
+            return true;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    return false;
+}
+
 test('engine utility functions should cover helper branches', async () => {
     assert.deepEqual(parseArrayJson(null), []);
     assert.deepEqual(parseArrayJson('[]'), []);
@@ -211,6 +232,38 @@ test('engine utility functions should cover helper branches', async () => {
     assert.equal(branchPolicy.defaultBranch, '陆军');
     assert.equal(Array.isArray(branchPolicy.rules), true);
     assert.equal(branchPolicy.rules.length >= 4, true);
+    assert.deepEqual(readNativeLookupConfig({}), {
+        enabled: false,
+        timeoutMs: 3000,
+        retryHours: 1,
+        targetBranches: ['海军', '海豹突击队'],
+    });
+    assert.deepEqual(readNativeLookupConfig({
+        native: {
+            enabled: true,
+            timeoutMs: 1200,
+            retryHours: 2,
+            targetBranches: ['海军', '空军', '海军'],
+        },
+    }), {
+        enabled: true,
+        timeoutMs: 1200,
+        retryHours: 2,
+        targetBranches: ['海军', '空军'],
+    });
+    assert.deepEqual(readNativeLookupConfig({
+        native: {
+            enabled: true,
+            targetBranches: [],
+        },
+    }).targetBranches, ['海军', '海豹突击队']);
+    assert.equal(isNativeRetryDue(null, '2026-03-14T00:00:00.000Z'), true);
+    assert.equal(isNativeRetryDue('2026-03-13T23:59:59.000Z', '2026-03-14T00:00:00.000Z'), true);
+    assert.equal(isNativeRetryDue('2026-03-14T00:10:00.000Z', '2026-03-14T00:00:00.000Z'), false);
+    assert.equal(isNativeRetryDue('bad-date', '2026-03-14T00:00:00.000Z'), true);
+    assert.equal(normalizeNativeLookupStatus('resolved'), 'resolved');
+    assert.equal(normalizeNativeLookupStatus('bad-value'), 'pending');
+    assert.equal(normalizeNativeLookupStatus(null), 'pending');
     const disabledPolicy = readBranchingConfig({ branching: { enabled: false } });
     assert.equal(disabledPolicy.enabled, false);
     const normalizedPolicy = readBranchingConfig({
@@ -1416,6 +1469,643 @@ test('applyCombatOutcome should return early when proxy does not exist', async (
         stage: '评分',
     });
     assert.equal(logger.entries.length, 0);
+});
+
+test('applyCombatOutcome should resolve native place asynchronously for target branches', async () => {
+    const h = createDbHandle();
+    const logger = createLogger();
+    h.config.native.enabled = true;
+    h.config.native.targetBranches = ['海军', '海豹突击队'];
+    const nowIso = '2026-03-14T09:30:00.000Z';
+    h.db.upsertSourceBatch(
+        [{ ip: '10.0.0.131', port: 8080, protocol: 'http' }],
+        () => '籍贯-成功-131',
+        'src',
+        'batch',
+        nowIso,
+    );
+    const proxy = h.db.getProxyList({ limit: 1 })[0];
+
+    const workerPool = {
+        async runTask() {
+            return { ok: true };
+        },
+        getStatus() {
+            return { workersTotal: 1, workersBusy: 0, queueSize: 0, runningTasks: 0, completedTasks: 0, failedTasks: 0, restartedWorkers: 0, workers: [] };
+        },
+    };
+    const engine = new ProxyHubEngine({
+        config: h.config,
+        db: h.db,
+        workerPool,
+        logger,
+        now: () => new Date(nowIso),
+    });
+    h.db.db.pragma('foreign_keys = OFF');
+    engine.resolveNativePlaceByIp = async () => ({
+        provider: 'ip-api',
+        country: '中国',
+        city: '北京',
+        place: '中国-北京',
+        rawJson: '{"status":"success","country":"中国","city":"北京"}',
+    });
+
+    await engine.applyCombatOutcome({
+        proxyId: proxy.id,
+        sourceName: 'battle-l2',
+        outcome: 'success',
+        latencyMs: 18,
+        nowIso,
+        stage: '评分(L2)',
+        combatStage: 'l2',
+    });
+
+    const resolved = await waitFor(() => h.db.getProxyById(proxy.id)?.native_lookup_status === 'resolved');
+    assert.equal(resolved, true);
+    const updated = h.db.getProxyById(proxy.id);
+    assert.equal(updated.service_branch, '海军');
+    assert.equal(updated.native_place, '中国-北京');
+    assert.equal(updated.native_provider, 'ip-api');
+    assert.equal(updated.native_lookup_raw_json.includes('"country":"中国"'), true);
+    assert.equal(h.db.getEvents(30).some((item) => item.event_type === 'native_lookup_resolved'), true);
+    assert.equal(logger.entries.some((item) => item.event === '籍贯解析成功'), true);
+
+    cleanupDb(h);
+});
+
+test('applyCombatOutcome should mark native lookup failed with retry and keep existing fields', async () => {
+    const h = createDbHandle();
+    const logger = createLogger();
+    h.config.native.enabled = true;
+    h.config.native.retryHours = 1;
+    const nowIso = '2026-03-14T09:40:00.000Z';
+    h.db.upsertSourceBatch(
+        [{ ip: '10.0.0.132', port: 8080, protocol: 'http' }],
+        () => '籍贯-失败-132',
+        'src',
+        'batch',
+        nowIso,
+    );
+    const proxy = h.db.getProxyList({ limit: 1 })[0];
+    h.db.updateProxyById(proxy.id, {
+        service_branch: '海军',
+        native_place: '未知',
+        native_country: '中国',
+        native_city: '上海',
+        native_lookup_status: 'pending',
+        native_next_retry_at: null,
+        updated_at: nowIso,
+    });
+
+    const workerPool = {
+        async runTask() {
+            return { ok: true };
+        },
+        getStatus() {
+            return { workersTotal: 1, workersBusy: 0, queueSize: 0, runningTasks: 0, completedTasks: 0, failedTasks: 0, restartedWorkers: 0, workers: [] };
+        },
+    };
+    const engine = new ProxyHubEngine({
+        config: h.config,
+        db: h.db,
+        workerPool,
+        logger,
+        now: () => new Date(nowIso),
+    });
+    engine.resolveNativePlaceByIp = async () => {
+        throw new Error('ip-api-timeout');
+    };
+
+    await engine.applyCombatOutcome({
+        proxyId: proxy.id,
+        sourceName: 'battle-l2',
+        outcome: 'network_error',
+        latencyMs: 0,
+        nowIso,
+        stage: '评分(L2)',
+        combatStage: 'l2',
+    });
+
+    const failed = await waitFor(() => h.db.getProxyById(proxy.id)?.native_lookup_status === 'failed');
+    assert.equal(failed, true);
+    const updated = h.db.getProxyById(proxy.id);
+    assert.equal(updated.native_place, '未知');
+    assert.equal(updated.native_country, '中国');
+    assert.equal(updated.native_city, '上海');
+    assert.equal(typeof updated.native_next_retry_at, 'string');
+    assert.equal(Date.parse(updated.native_next_retry_at) > Date.parse(nowIso), true);
+    assert.equal(h.db.getEvents(30).some((item) => item.event_type === 'native_lookup_failed'), true);
+    assert.equal(logger.entries.some((item) => item.event === '籍贯解析失败' && item.reason === 'ip-api-timeout'), true);
+
+    cleanupDb(h);
+});
+
+test('applyCombatOutcome should skip non-target branch and honor native retry window', async () => {
+    const h = createDbHandle();
+    const logger = createLogger();
+    h.config.native.enabled = true;
+    h.config.native.targetBranches = ['海军'];
+    const nowIso = '2026-03-14T09:50:00.000Z';
+    h.db.upsertSourceBatch(
+        [{ ip: '10.0.0.133', port: 8080, protocol: 'http' }],
+        () => '籍贯-跳过-133',
+        'src',
+        'batch',
+        nowIso,
+    );
+    const proxy = h.db.getProxyList({ limit: 1 })[0];
+
+    const workerPool = {
+        async runTask() {
+            return { ok: true };
+        },
+        getStatus() {
+            return { workersTotal: 1, workersBusy: 0, queueSize: 0, runningTasks: 0, completedTasks: 0, failedTasks: 0, restartedWorkers: 0, workers: [] };
+        },
+    };
+    let lookupCalls = 0;
+    let currentNow = nowIso;
+    const engine = new ProxyHubEngine({
+        config: h.config,
+        db: h.db,
+        workerPool,
+        logger,
+        now: () => new Date(currentNow),
+    });
+    engine.resolveNativePlaceByIp = async () => {
+        lookupCalls += 1;
+        return {
+            provider: 'ip-api',
+            country: '中国',
+            city: '广州',
+            place: '中国-广州',
+            rawJson: '{"status":"success","country":"中国","city":"广州"}',
+        };
+    };
+
+    await engine.applyCombatOutcome({
+        proxyId: proxy.id,
+        sourceName: 'src',
+        outcome: 'success',
+        latencyMs: 10,
+        nowIso,
+        stage: '评分(L0)',
+        combatStage: 'l0',
+    });
+    const skipped = await waitFor(() => h.db.getProxyById(proxy.id)?.native_lookup_status === 'skipped');
+    assert.equal(skipped, true);
+    assert.equal(lookupCalls, 0);
+
+    h.db.updateProxyById(proxy.id, {
+        service_branch: '海军',
+        native_place: '未知',
+        native_lookup_status: 'failed',
+        native_next_retry_at: '2026-03-14T10:30:00.000Z',
+        updated_at: nowIso,
+    });
+    currentNow = '2026-03-14T10:00:00.000Z';
+    await engine.applyCombatOutcome({
+        proxyId: proxy.id,
+        sourceName: 'battle-l2',
+        outcome: 'success',
+        latencyMs: 12,
+        nowIso: currentNow,
+        stage: '评分(L2)',
+        combatStage: 'l2',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(lookupCalls, 0);
+
+    h.db.updateProxyById(proxy.id, {
+        native_next_retry_at: '2026-03-14T09:00:00.000Z',
+        updated_at: currentNow,
+    });
+    currentNow = '2026-03-14T10:40:00.000Z';
+    await engine.applyCombatOutcome({
+        proxyId: proxy.id,
+        sourceName: 'battle-l2',
+        outcome: 'success',
+        latencyMs: 12,
+        nowIso: currentNow,
+        stage: '评分(L2)',
+        combatStage: 'l2',
+    });
+    const resolved = await waitFor(() => h.db.getProxyById(proxy.id)?.native_lookup_status === 'resolved');
+    assert.equal(resolved, true);
+    assert.equal(lookupCalls, 1);
+    assert.equal(h.db.getProxyById(proxy.id).native_place, '中国-广州');
+    cleanupDb(h);
+});
+
+test('resolveNativePlaceByIp should cover unavailable/http/json/status/success branches', async () => {
+    const logger = createLogger();
+    const config = createConfig(path.join(os.tmpdir(), 'proxyhub-engine-native-resolve.db'));
+    config.native.enabled = true;
+    const db = {
+        getProxyById() {
+            return null;
+        },
+    };
+    const workerPool = {
+        getStatus() {
+            return { workersTotal: 1, workersBusy: 0, queueSize: 0, runningTasks: 0, completedTasks: 0, failedTasks: 0, restartedWorkers: 0, workers: [] };
+        },
+    };
+    const engine = new ProxyHubEngine({ config, db, workerPool, logger });
+    const oldFetch = global.fetch;
+    const oldAbortSignal = global.AbortSignal;
+    const oldJsonParse = JSON.parse;
+
+    try {
+        global.fetch = undefined;
+        await assert.rejects(
+            () => engine.resolveNativePlaceByIp('1.1.1.1', 800),
+            /ip-api-fetch-unavailable/,
+        );
+
+        global.fetch = async () => ({
+            ok: true,
+            status: 200,
+            async text() {
+                return '{"status":"success"}';
+            },
+        });
+        await assert.rejects(
+            () => engine.resolveNativePlaceByIp('', 800),
+            /ip-api-ip-missing/,
+        );
+
+        global.AbortSignal = undefined;
+        global.fetch = async () => ({
+            ok: false,
+            status: 500,
+            async text() {
+                return '';
+            },
+        });
+        await assert.rejects(
+            () => engine.resolveNativePlaceByIp('2.2.2.2', 900),
+            /ip-api-http-500/,
+        );
+
+        global.AbortSignal = oldAbortSignal;
+        global.fetch = async () => ({
+            ok: true,
+            status: 200,
+            async text() {
+                return '{bad-json';
+            },
+        });
+        await assert.rejects(
+            () => engine.resolveNativePlaceByIp('3.3.3.3', 900),
+            /ip-api-invalid-json/,
+        );
+
+        global.fetch = async () => ({
+            ok: true,
+            status: 200,
+            async text() {
+                return JSON.stringify({ status: 'fail', message: 'quota' });
+            },
+        });
+        await assert.rejects(
+            () => engine.resolveNativePlaceByIp('4.4.4.4', 900),
+            /ip-api-quota/,
+        );
+
+        global.fetch = async () => ({
+            ok: true,
+            status: 200,
+            async text() {
+                return JSON.stringify({ country: '美国', city: '纽约' });
+            },
+        });
+        await assert.rejects(
+            () => engine.resolveNativePlaceByIp('4.4.4.5', 900),
+            /ip-api-request-failed/,
+        );
+
+        global.fetch = async () => ({
+            ok: true,
+            status: 200,
+            async text() {
+                return JSON.stringify({ status: 'success', country: '日本', city: '' });
+            },
+        });
+        const resolved = await engine.resolveNativePlaceByIp('5.5.5.5', 900);
+        assert.equal(resolved.provider, 'ip-api');
+        assert.equal(resolved.place, '日本-未知');
+
+        global.fetch = async () => ({
+            ok: true,
+            status: 200,
+            async text() {
+                return JSON.stringify({ status: 'success', country: '', city: '首尔' });
+            },
+        });
+        const fallbackCountry = await engine.resolveNativePlaceByIp('5.5.5.6', 0);
+        assert.equal(fallbackCountry.place, '未知-首尔');
+
+        JSON.parse = (raw) => {
+            if (raw === '') {
+                return { status: 'success', country: '中国', city: '厦门' };
+            }
+            return oldJsonParse(raw);
+        };
+        global.fetch = async () => ({
+            ok: true,
+            status: 200,
+            async text() {
+                return '';
+            },
+        });
+        const fallbackRawJson = await engine.resolveNativePlaceByIp('5.5.5.7', 900);
+        assert.equal(fallbackRawJson.place, '中国-厦门');
+        assert.equal(fallbackRawJson.rawJson, JSON.stringify({ status: 'success', country: '中国', city: '厦门' }));
+    } finally {
+        global.fetch = oldFetch;
+        global.AbortSignal = oldAbortSignal;
+        JSON.parse = oldJsonParse;
+    }
+});
+
+test('native lookup decision/task/schedule helpers should cover edge branches', async () => {
+    const h = createDbHandle();
+    const logger = createLogger();
+    h.config.native.enabled = true;
+    h.config.native.targetBranches = ['海军'];
+    const nowIso = '2026-03-14T11:20:00.000Z';
+    h.db.upsertSourceBatch(
+        [{ ip: '10.0.0.134', port: 8080, protocol: 'http' }],
+        () => '籍贯-边界-134',
+        'src',
+        'batch',
+        nowIso,
+    );
+    const proxy = h.db.getProxyList({ limit: 1 })[0];
+
+    const workerPool = {
+        async runTask() {
+            return { ok: true };
+        },
+        getStatus() {
+            return { workersTotal: 1, workersBusy: 0, queueSize: 0, runningTasks: 0, completedTasks: 0, failedTasks: 0, restartedWorkers: 0, workers: [] };
+        },
+    };
+    const engine = new ProxyHubEngine({
+        config: h.config,
+        db: h.db,
+        workerPool,
+        logger,
+        now: () => new Date(nowIso),
+    });
+
+    const missingDecision = engine.resolveNativeLookupDecision(null, nowIso);
+    assert.equal(missingDecision.action, 'none');
+    assert.equal(missingDecision.reason, 'proxy-missing');
+
+    h.db.updateProxyById(proxy.id, {
+        native_lookup_status: 'skipped',
+        updated_at: nowIso,
+    });
+    const nonTargetDecision = engine.resolveNativeLookupDecision(h.db.getProxyById(proxy.id), nowIso);
+    assert.equal(nonTargetDecision.action, 'none');
+    assert.equal(nonTargetDecision.reason, 'branch-not-target');
+    const missingBranchDecision = engine.resolveNativeLookupDecision({
+        id: proxy.id,
+        service_branch: null,
+        native_place: '未知',
+        native_lookup_status: null,
+        native_next_retry_at: null,
+    }, nowIso);
+    assert.equal(missingBranchDecision.action, 'skip');
+    assert.equal(missingBranchDecision.reason, 'branch-not-target');
+
+    h.db.updateProxyById(proxy.id, {
+        service_branch: '海军',
+        native_place: '中国-上海',
+        updated_at: nowIso,
+    });
+    const knownDecision = engine.resolveNativeLookupDecision(h.db.getProxyById(proxy.id), nowIso);
+    assert.equal(knownDecision.action, 'none');
+    assert.equal(knownDecision.reason, 'native-already-known');
+    const emptyNativePlaceDecision = engine.resolveNativeLookupDecision({
+        id: proxy.id,
+        service_branch: '海军',
+        native_place: '',
+        native_lookup_status: 'pending',
+        native_next_retry_at: null,
+    }, nowIso);
+    assert.equal(emptyNativePlaceDecision.action, 'lookup');
+    assert.equal(emptyNativePlaceDecision.reason, 'eligible');
+
+    await engine.runNativeLookupTask(99999, 'src');
+
+    h.db.updateProxyById(proxy.id, {
+        service_branch: '陆军',
+        native_place: '未知',
+        native_lookup_status: 'pending',
+        native_next_retry_at: null,
+        updated_at: nowIso,
+    });
+    await engine.runNativeLookupTask(proxy.id, 'src');
+    assert.equal(h.db.getProxyById(proxy.id).native_lookup_status, 'skipped');
+
+    h.db.updateProxyById(proxy.id, {
+        service_branch: '海军',
+        native_place: '未知',
+        native_lookup_status: 'failed',
+        native_next_retry_at: '2099-01-01T00:00:00.000Z',
+        updated_at: nowIso,
+    });
+    await engine.runNativeLookupTask(proxy.id, 'src');
+    assert.equal(h.db.getProxyById(proxy.id).native_lookup_status, 'failed');
+
+    h.db.updateProxyById(proxy.id, {
+        service_branch: '海军',
+        native_place: '未知',
+        native_lookup_status: 'pending',
+        native_next_retry_at: null,
+        updated_at: nowIso,
+    });
+    engine.resolveNativePlaceByIp = async () => {
+        h.db.updateProxyById(proxy.id, {
+            native_place: '中国-深圳',
+            updated_at: nowIso,
+        });
+        return {
+            provider: 'ip-api',
+            country: '中国',
+            city: '广州',
+            place: '中国-广州',
+            rawJson: '{"status":"success"}',
+        };
+    };
+    await engine.runNativeLookupTask(proxy.id, 'src');
+    assert.equal(h.db.getProxyById(proxy.id).native_place, '中国-深圳');
+
+    h.db.updateProxyById(proxy.id, {
+        service_branch: '海军',
+        native_place: '未知',
+        native_lookup_status: 'pending',
+        native_next_retry_at: null,
+        updated_at: nowIso,
+    });
+    engine.resolveNativePlaceByIp = async () => {
+        h.db.updateProxyById(proxy.id, {
+            native_place: '中国-杭州',
+            updated_at: nowIso,
+        });
+        throw new Error('ip-api-recheck-fail');
+    };
+    await engine.runNativeLookupTask(proxy.id, 'src');
+    assert.equal(h.db.getProxyById(proxy.id).native_lookup_status, 'pending');
+
+    h.db.updateProxyById(proxy.id, {
+        service_branch: '海军',
+        native_place: '未知',
+        native_lookup_status: 'pending',
+        native_next_retry_at: null,
+        updated_at: nowIso,
+    });
+    engine.nativeLookupInFlight.add(proxy.id);
+    engine.scheduleNativeLookup(h.db.getProxyById(proxy.id), 'src', nowIso);
+    assert.equal(engine.nativeLookupInFlight.has(proxy.id), true);
+    engine.nativeLookupInFlight.delete(proxy.id);
+
+    engine.runNativeLookupTask = async () => {
+        throw new Error('native-lookup-task-failed');
+    };
+    engine.scheduleNativeLookup(h.db.getProxyById(proxy.id), 'src', nowIso);
+    const logged = await waitFor(() => logger.entries.some((item) => item.reason === 'native-lookup-task-failed'));
+    assert.equal(logged, true);
+
+    const originalGetProxyById = h.db.getProxyById.bind(h.db);
+    h.db.getProxyById = () => null;
+    engine.markNativeLookupSkipped({
+        id: proxy.id,
+        display_name: '籍贯-跳过-兜底',
+        ip: '10.0.0.134',
+        service_branch: '陆军',
+    }, 'src', nowIso, 'branch-not-target');
+    h.db.getProxyById = originalGetProxyById;
+    assert.equal(logger.entries.some((item) => item.event === '籍贯解析跳过' && item.proxyName === '籍贯-跳过-兜底'), true);
+
+    cleanupDb(h);
+});
+
+test('native lookup should fallback to cached proxy when db row disappears and default error reason', async () => {
+    const h = createDbHandle();
+    const logger = createLogger();
+    h.config.native.enabled = true;
+    h.config.native.targetBranches = ['海军'];
+    const nowIso = '2026-03-14T11:40:00.000Z';
+    h.db.upsertSourceBatch(
+        [{ ip: '10.0.0.135', port: 8080, protocol: 'http' }],
+        () => '籍贯-并发删除-135',
+        'src',
+        'batch',
+        nowIso,
+    );
+    h.db.upsertSourceBatch(
+        [{ ip: '10.0.0.136', port: 8080, protocol: 'http' }],
+        () => '籍贯-并发删除-136',
+        'src',
+        'batch',
+        nowIso,
+    );
+    const proxies = h.db.getProxyList({ limit: 5 });
+    const proxySuccess = proxies.find((item) => item.ip === '10.0.0.135');
+    const proxyFailure = proxies.find((item) => item.ip === '10.0.0.136');
+    assert.ok(proxySuccess);
+    assert.ok(proxyFailure);
+
+    h.db.updateProxyById(proxySuccess.id, {
+        service_branch: '海军',
+        native_place: '未知',
+        native_lookup_status: 'pending',
+        native_next_retry_at: null,
+        updated_at: nowIso,
+    });
+    h.db.updateProxyById(proxyFailure.id, {
+        service_branch: '海军',
+        native_place: '未知',
+        native_lookup_status: 'pending',
+        native_next_retry_at: null,
+        updated_at: nowIso,
+    });
+
+    const workerPool = {
+        async runTask() {
+            return { ok: true };
+        },
+        getStatus() {
+            return { workersTotal: 1, workersBusy: 0, queueSize: 0, runningTasks: 0, completedTasks: 0, failedTasks: 0, restartedWorkers: 0, workers: [] };
+        },
+    };
+    const engine = new ProxyHubEngine({
+        config: h.config,
+        db: h.db,
+        workerPool,
+        logger,
+        now: () => new Date(nowIso),
+    });
+    const realGetProxyById = h.db.getProxyById.bind(h.db);
+    let forceNullGetById = false;
+    h.db.getProxyById = (id) => (forceNullGetById ? null : realGetProxyById(id));
+
+    engine.resolveNativePlaceByIp = async (ip) => {
+        if (ip === proxySuccess.ip) {
+            forceNullGetById = true;
+            return {
+                provider: 'ip-api',
+                country: '中国',
+                city: '成都',
+                place: '中国-成都',
+                rawJson: '{"status":"success","country":"中国","city":"成都"}',
+            };
+        }
+        throw new Error(`unexpected-ip-${ip}`);
+    };
+    await engine.runNativeLookupTask(proxySuccess.id, 'src');
+    forceNullGetById = false;
+    assert.equal(logger.entries.some((item) => item.event === '籍贯解析成功' && item.proxyName === proxySuccess.display_name), true);
+    assert.equal(h.db.getEvents(30).some((item) => item.event_type === 'native_lookup_resolved'), true);
+
+    engine.resolveNativeLookupDecision = () => ({
+        action: 'lookup',
+        reason: 'forced',
+        policy: {
+            enabled: true,
+            timeoutMs: 800,
+            retryHours: 0,
+            targetBranches: ['海军'],
+        },
+    });
+    engine.resolveNativePlaceByIp = async () => {
+        forceNullGetById = true;
+        throw null;
+    };
+    await engine.runNativeLookupTask(proxyFailure.id, 'src');
+    forceNullGetById = false;
+    assert.equal(logger.entries.some((item) => item.event === '籍贯解析失败' && item.proxyName === proxyFailure.display_name && item.reason === 'native-lookup-failed'), true);
+    assert.equal(h.db.getEvents(30).some((item) => item.event_type === 'native_lookup_failed'), true);
+
+    engine.runNativeLookupTask = async () => {
+        throw null;
+    };
+    engine.scheduleNativeLookup({
+        id: 778899,
+        ip: '10.0.0.177',
+        display_name: '籍贯-调度-回退-177',
+        service_branch: '海军',
+        native_place: '未知',
+    }, 'src', nowIso);
+    const fallbackLogged = await waitFor(() => logger.entries.some((item) => item.reason === 'native-lookup-task-failed'));
+    assert.equal(fallbackLogged, true);
+    h.db.getProxyById = realGetProxyById;
+
+    cleanupDb(h);
 });
 
 test('resolveBranchingTransition should support custom rule extension', () => {

--- a/apps/proxy-pool-service/src/server.test.js
+++ b/apps/proxy-pool-service/src/server.test.js
@@ -135,6 +135,8 @@ function createStubs() {
             id: 7,
             ip_value_score: 88.8,
             service_branch: '陆军',
+            native_place: '未知',
+            native_lookup_raw_json: '',
             l0_success_count: 9,
             l0_fail_count: 1,
             l1_success_count: 4,
@@ -308,6 +310,8 @@ test('server runtime should expose all REST endpoints and shutdown cleanly', asy
     assert.equal(typeof valueBoardPayload.items[0].l2_fail_count, 'number');
     assert.equal(typeof valueBoardPayload.items[0].l3_success_count, 'number');
     assert.equal(typeof valueBoardPayload.items[0].l3_fail_count, 'number');
+    assert.equal(typeof valueBoardPayload.items[0].native_place, 'string');
+    assert.equal(typeof valueBoardPayload.items[0].native_lookup_raw_json, 'string');
 
     const patchOk = await fetch(baseUrl + '/v1/proxies/policy', {
         method: 'POST',

--- a/apps/proxy-pool-service/src/views.test.js
+++ b/apps/proxy-pool-service/src/views.test.js
@@ -19,10 +19,13 @@ test('renderProxyAdminPage should inject refresh interval', () => {
     assert.equal(html.includes('按价值分从高到低排的名次，1就是当前最有价值的IP。'), true);
     assert.equal(html.includes('系统一共'), true);
     assert.equal(html.includes("label: '编制'"), true);
+    assert.equal(html.includes("label: '籍贯'"), true);
     assert.equal(html.includes("const displayNameWithBranch ="), false);
     assert.equal(html.includes(" + ' [' + serviceBranch + ']'"), false);
     assert.equal(html.includes("esc(displayName) + '</td>'"), true);
     assert.equal(html.includes("esc(serviceBranch) + '</td>'"), true);
+    assert.equal(html.includes("const nativeTip = nativePlace === '未知'"), true);
+    assert.equal(html.includes("'<td title=\"' + esc(nativeTip) + '\">' + esc(nativePlace) + '</td>'"), true);
     assert.equal(html.includes("label: 'L0(成功/失败)'"), true);
     assert.equal(html.includes("label: 'L1(成功/失败)'"), true);
     assert.equal(html.includes("label: 'L2(成功/失败)'"), true);

--- a/apps/proxy-pool-service/src/views/proxy-admin.html
+++ b/apps/proxy-pool-service/src/views/proxy-admin.html
@@ -114,6 +114,7 @@ function getValueBoardHeaders(rankHelp) {
     { label: '姓名', help: '这个IP的显示名称，方便在日志和榜单里快速识别。' },
     { label: '编制', help: '该IP当前所属军种编制，用于体现兵种归属。' },
     { label: '军衔', help: rankHelp },
+    { label: '籍贯', help: 'IP归属地（国家-城市）。悬停可查看解析详情；未知时显示“未知”。' },
     { label: '价值分', help: '这是0到100的综合分，分数越高说明这个IP越值得优先使用。' },
     { label: '生命周期', help: '这个IP现在处于哪个阶段（候选/在役/预备/退役），决定它会不会被优先调度。' },
     { label: '成功率', help: '历史成功次数除以总样本数，反映总体能不能跑通。' },
@@ -239,12 +240,17 @@ async function loadAll() {
     const updatedUtc = x.updated_at || '-';
     const displayName = x.display_name || '-';
     const serviceBranch = x.service_branch || '陆军';
+    const nativePlace = x.native_place || '未知';
+    const nativeTip = nativePlace === '未知'
+      ? '未知'
+      : (x.native_lookup_raw_json || '未知');
     return ''
       + '<tr>'
       + '<td>' + (index + 1) + '</td>'
       + '<td>' + esc(displayName) + '</td>'
       + '<td>' + esc(serviceBranch) + '</td>'
       + '<td>' + esc(x.rank) + '</td>'
+      + '<td title="' + esc(nativeTip) + '">' + esc(nativePlace) + '</td>'
       + '<td class="ok">' + fmtScore(x.ip_value_score) + '</td>'
       + '<td>' + esc(x.lifecycle) + '</td>'
       + '<td>' + fmtPercent(x.success_ratio) + '</td>'


### PR DESCRIPTION
## Summary
- 在价值榜新增“籍贯”列（位于“军衔”后）并支持 hover 提示。
- 引入原生籍贯异步解析：仅对目标兵种、籍贯未知、且到重试时间的代理调用 ip-api。
- 兵种目标改为环境变量白名单（CSV），后续加入“空军”等无需改代码。

## Changes
- 扩展 proxies 字段与增量迁移：
  - 
ative_place
  - 
ative_country
  - 
ative_city
  - 
ative_provider
  - 
ative_resolved_at
  - 
ative_lookup_status
  - 
ative_next_retry_at
  - 
ative_lookup_raw_json
- 新增配置：
  - PROXY_HUB_NATIVE_ENABLED
  - PROXY_HUB_NATIVE_TIMEOUT_MS
  - PROXY_HUB_NATIVE_RETRY_HOURS
  - PROXY_HUB_NATIVE_TARGET_BRANCHES
- 引擎接入异步旁路逻辑（不阻塞 pplyCombatOutcome）：
  - 成功写入 country/city/place/provider/resolved_at/status/raw_json
  - 失败仅写 status/retry，不覆盖已有籍贯值
  - 非目标兵种首次写 skipped，后续不重复刷写
  - in-flight 防抖避免并发重复查询
- API/UI：
  - alue-board 返回 
ative_place 与 
ative_lookup_raw_json
  - 列顺序调整为 ... 编制, 军衔, 籍贯, 价值分 ...
  - hover 规则：未知 -> 显示“未知”，有值 -> 显示 
ative_lookup_raw_json 原文

## Test
- 
pm.cmd --prefix repo run test:proxyhub:coverage
- 覆盖率：lines 100%, statements 100%, functions 100%, branches 98.12%

Closes #77