### PR TITLE
feat(proxyhub-admin): simplify L0-L3 display format and support live template reload

### DIFF
--- a/apps/proxy-pool-service/src/views.test.js
+++ b/apps/proxy-pool-service/src/views.test.js
@@ -26,14 +26,20 @@ test('renderProxyAdminPage should inject refresh interval', () => {
     assert.equal(html.includes("esc(serviceBranch) + '</td>'"), true);
     assert.equal(html.includes("const nativeTip = nativePlace === '未知'"), true);
     assert.equal(html.includes("'<td title=\"' + esc(nativeTip) + '\">' + esc(nativePlace) + '</td>'"), true);
-    assert.equal(html.includes("label: 'L0(成功/失败)'"), true);
-    assert.equal(html.includes("label: 'L1(成功/失败)'"), true);
-    assert.equal(html.includes("label: 'L2(成功/失败)'"), true);
-    assert.equal(html.includes("label: 'L3(成功/失败)'"), true);
-    assert.equal(html.includes("fmt(x.l0_success_count) + '/' + fmt(x.l0_fail_count)"), true);
-    assert.equal(html.includes("fmt(x.l1_success_count) + '/' + fmt(x.l1_fail_count)"), true);
-    assert.equal(html.includes("fmt(x.l2_success_count) + '/' + fmt(x.l2_fail_count)"), true);
-    assert.equal(html.includes("fmt(x.l3_success_count) + '/' + fmt(x.l3_fail_count)"), true);
+    assert.equal(html.includes("label: 'L0'"), true);
+    assert.equal(html.includes("label: 'L1'"), true);
+    assert.equal(html.includes("label: 'L2'"), true);
+    assert.equal(html.includes("label: 'L3'"), true);
+    assert.equal(html.includes("help: 'L0'"), true);
+    assert.equal(html.includes("help: 'L1'"), true);
+    assert.equal(html.includes("help: 'L2'"), true);
+    assert.equal(html.includes("help: 'L3'"), true);
+    assert.equal(html.includes('function fmtSuccessTotalPercent(success, total)'), true);
+    assert.equal(html.includes("toFixed(1)"), true);
+    assert.equal(html.includes("fmtSuccessTotalPercent(x.l0_success_count, l0Total)"), true);
+    assert.equal(html.includes("fmtSuccessTotalPercent(x.l1_success_count, l1Total)"), true);
+    assert.equal(html.includes("fmtSuccessTotalPercent(x.l2_success_count, l2Total)"), true);
+    assert.equal(html.includes("fmtSuccessTotalPercent(x.l3_success_count, l3Total)"), true);
 });
 
 test('renderRuntimeLogsPage should return static html', () => {

--- a/apps/proxy-pool-service/src/views/proxy-admin.html
+++ b/apps/proxy-pool-service/src/views/proxy-admin.html
@@ -96,6 +96,12 @@ function fmt(n) { return n == null ? '-' : n; }
 function esc(v) { return String(v == null ? '-' : v).replace(/[&<>"']/g, function(m){ return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]; }); }
 function fmtPercent(ratio) { return fmt(Number((Number(ratio || 0) * 100).toFixed(1))) + '%'; }
 function fmtScore(value) { return fmt(Number(value || 0).toFixed(2)); }
+function fmtSuccessTotalPercent(success, total) {
+  const s = Number(success || 0);
+  const t = Number(total || 0);
+  const ratio = t > 0 ? Number(((s / t) * 100).toFixed(1)) : 0;
+  return fmt(s) + '/' + fmt(t) + '（' + fmt(ratio) + '%）';
+}
 function fmtLocalTime(iso) {
   const ms = Date.parse(iso);
   if (!Number.isFinite(ms)) return '-';
@@ -119,10 +125,10 @@ function getValueBoardHeaders(rankHelp) {
     { label: '生命周期', help: '这个IP现在处于哪个阶段（候选/在役/预备/退役），决定它会不会被优先调度。' },
     { label: '成功率', help: '历史成功次数除以总样本数，反映总体能不能跑通。' },
     { label: '战场胜率', help: '战场测试里成功次数除以战场总次数，反映真实战场好不好用。' },
-    { label: 'L0(成功/失败)', help: 'L0层的累计成功/失败次数，失败包含 blocked、timeout、network_error、invalid_feedback。' },
-    { label: 'L1(成功/失败)', help: 'L1战场测试的累计成功/失败次数。' },
-    { label: 'L2(成功/失败)', help: 'L2战场测试的累计成功/失败次数。' },
-    { label: 'L3(成功/失败)', help: 'L3战场测试的累计成功/失败次数。' },
+    { label: 'L0', help: 'L0' },
+    { label: 'L1', help: 'L1' },
+    { label: 'L2', help: 'L2' },
+    { label: 'L3', help: 'L3' },
     { label: '激活荣誉', help: '当前生效中的荣誉标签，代表这个IP最近在某些维度表现突出。' },
     { label: '地址', help: 'IP、端口和协议组合地址，排障和复现问题时最直接。' },
     { label: '来源', help: '这个IP来自哪个抓取源，可用来判断源质量。' },
@@ -244,6 +250,10 @@ async function loadAll() {
     const nativeTip = nativePlace === '未知'
       ? '未知'
       : (x.native_lookup_raw_json || '未知');
+    const l0Total = Number(x.l0_success_count || 0) + Number(x.l0_fail_count || 0);
+    const l1Total = Number(x.l1_success_count || 0) + Number(x.l1_fail_count || 0);
+    const l2Total = Number(x.l2_success_count || 0) + Number(x.l2_fail_count || 0);
+    const l3Total = Number(x.l3_success_count || 0) + Number(x.l3_fail_count || 0);
     return ''
       + '<tr>'
       + '<td>' + (index + 1) + '</td>'
@@ -255,10 +265,10 @@ async function loadAll() {
       + '<td>' + esc(x.lifecycle) + '</td>'
       + '<td>' + fmtPercent(x.success_ratio) + '</td>'
       + '<td>' + fmtPercent(x.battle_ratio) + '</td>'
-      + '<td class="mono">' + fmt(x.l0_success_count) + '/' + fmt(x.l0_fail_count) + '</td>'
-      + '<td class="mono">' + fmt(x.l1_success_count) + '/' + fmt(x.l1_fail_count) + '</td>'
-      + '<td class="mono">' + fmt(x.l2_success_count) + '/' + fmt(x.l2_fail_count) + '</td>'
-      + '<td class="mono">' + fmt(x.l3_success_count) + '/' + fmt(x.l3_fail_count) + '</td>'
+      + '<td class="mono">' + fmtSuccessTotalPercent(x.l0_success_count, l0Total) + '</td>'
+      + '<td class="mono">' + fmtSuccessTotalPercent(x.l1_success_count, l1Total) + '</td>'
+      + '<td class="mono">' + fmtSuccessTotalPercent(x.l2_success_count, l2Total) + '</td>'
+      + '<td class="mono">' + fmtSuccessTotalPercent(x.l3_success_count, l3Total) + '</td>'
       + '<td>' + esc(honorText) + '</td>'
       + '<td class="mono">' + esc(address) + '</td>'
       + '<td>' + esc(x.source) + '</td>'

--- a/apps/proxy-pool-service/src/views/proxy-admin.js
+++ b/apps/proxy-pool-service/src/views/proxy-admin.js
@@ -2,10 +2,10 @@
 const path = require('node:path');
 
 const templatePath = path.join(__dirname, 'proxy-admin.html');
-const template = fs.readFileSync(templatePath, 'utf8');
 
 // 0131_renderProxyAdminPage_渲染代理管理页面逻辑
 function renderProxyAdminPage(config) {
+    const template = fs.readFileSync(templatePath, 'utf8');
     return template.replaceAll('__REFRESH_MS__', String(config.ui.refreshMs));
 }
 


### PR DESCRIPTION
Summary: L0-L3 headers simplified to L0/L1/L2/L3; cell values switched to success/total（x.x%）; proxy-admin template is loaded per request so soak/runtime picks HTML changes without restart.\n\nVerification: npm.cmd run test:proxyhub:unit; npm.cmd run test:proxyhub:coverage; coverage gate passed (lines 100, statements 100, functions 100, branches 98.13).\n\nCloses #81