### PR TITLE
feat(proxyhub): align L2/L3 profile schedules and soak effective timeline

### DIFF
--- a/apps/proxy-pool-service/src/config.js
+++ b/apps/proxy-pool-service/src/config.js
@@ -221,6 +221,14 @@ const l2LookbackByProfile = {
     production: 20,
     soak: 25,
 };
+const battleL2SyncMsByProfile = {
+    production: 900_000,
+    soak: 600_000,
+};
+const battleL3SyncMsByProfile = {
+    production: 1_200_000,
+    soak: 600_000,
+};
 
 const defaultBattleL3Targets = [
     {
@@ -228,6 +236,12 @@ const defaultBattleL3Targets = [
         url: process.env.PROXY_HUB_BATTLE_L3_PRIMARY_URL
             || process.env.PROXY_HUB_BATTLE_L2_PRIMARY_URL
             || 'https://www.ly.com/flights/home',
+    },
+    {
+        name: 'baidu-browser',
+        url: process.env.PROXY_HUB_BATTLE_L3_SECONDARY_URL
+            || process.env.PROXY_HUB_BATTLE_L2_FALLBACK_URL
+            || 'https://www.baidu.com',
     },
 ];
 const resolvedBattleL3Targets = parseJsonArrayEnv(
@@ -484,7 +498,8 @@ module.exports = {
     battle: {
         enabled: String(process.env.PROXY_HUB_BATTLE_ENABLED || 'true') === 'true',
         l1SyncMs: Number(process.env.PROXY_HUB_BATTLE_L1_MS || 300_000),
-        l2SyncMs: Number(process.env.PROXY_HUB_BATTLE_L2_MS || 1_800_000),
+        l2SyncMs: Number(process.env.PROXY_HUB_BATTLE_L2_MS || battleL2SyncMsByProfile[activeProfile] || 1_800_000),
+        l2SyncMsByProfile: deepClone(battleL2SyncMsByProfile),
         maxBattleL1PerCycle: Number(process.env.PROXY_HUB_BATTLE_L1_MAX || 60),
         maxBattleL2PerCycle: Number(process.env.PROXY_HUB_BATTLE_L2_MAX || 20),
         candidateQuota: Number(process.env.PROXY_HUB_BATTLE_CANDIDATE_QUOTA || battleL1LifecycleQuotaByProfile[activeProfile].candidate),
@@ -496,13 +511,14 @@ module.exports = {
         },
         l3: {
             enabled: toBool(process.env.PROXY_HUB_BATTLE_L3_ENABLED, true),
-            syncMs: Number(process.env.PROXY_HUB_BATTLE_L3_MS || 2_700_000),
+            syncMs: Number(process.env.PROXY_HUB_BATTLE_L3_MS || battleL3SyncMsByProfile[activeProfile] || 2_700_000),
             maxPerCycle: Number(process.env.PROXY_HUB_BATTLE_L3_MAX || 12),
             concurrency: Number(process.env.PROXY_HUB_BATTLE_L3_CONCURRENCY || 3),
             lookbackMinutes: Number(process.env.PROXY_HUB_BATTLE_L3_LOOKBACK_MINUTES || l2LookbackByProfile[activeProfile]),
-            timeoutMs: Number(process.env.PROXY_HUB_BATTLE_L3_TIMEOUT_MS || 12_000),
+            timeoutMs: Number(process.env.PROXY_HUB_BATTLE_L3_TIMEOUT_MS || 18_000),
             allowedProtocols: deepClone(resolvedBattleL3Protocols),
             targets: deepClone(resolvedBattleL3Targets),
+            syncMsByProfile: deepClone(battleL3SyncMsByProfile),
         },
         blockedStatusCodes: [401, 403, 429, 503],
         blockSignals: [

--- a/apps/proxy-pool-service/src/config.test.js
+++ b/apps/proxy-pool-service/src/config.test.js
@@ -5,6 +5,8 @@ function loadConfigWithEnv(overrides = {}) {
     const managedKeys = new Set([
         'PROXY_HUB_BATTLE_L2_PRIMARY_URL',
         'PROXY_HUB_BATTLE_L3_PRIMARY_URL',
+        'PROXY_HUB_BATTLE_L3_SECONDARY_URL',
+        'PROXY_HUB_BATTLE_L2_FALLBACK_URL',
         'PROXY_HUB_BATTLE_L3_ENABLED',
         'PROXY_HUB_BATTLE_L3_MS',
         'PROXY_HUB_BATTLE_L3_MAX',
@@ -13,6 +15,7 @@ function loadConfigWithEnv(overrides = {}) {
         'PROXY_HUB_BATTLE_L3_TIMEOUT_MS',
         'PROXY_HUB_BATTLE_L3_ALLOWED_PROTOCOLS',
         'PROXY_HUB_BATTLE_L3_TARGETS_JSON',
+        'PROXY_HUB_BATTLE_L2_MS',
         'PROXY_HUB_FEATURE_STAGE_WEIGHTING',
         'PROXY_HUB_FEATURE_LIFECYCLE_HYSTERESIS',
         'PROXY_HUB_FEATURE_HONOR_PROMOTION_TUNING',
@@ -99,16 +102,21 @@ test('config should expose required default values', { concurrency: false }, () 
     assert.equal(config.branching.rules.length >= 4, true);
     assert.equal(config.battle.enabled, true);
     assert.equal(config.battle.l1SyncMs, 300000);
-    assert.equal(config.battle.l2SyncMs, 1800000);
+    assert.equal(config.battle.l2SyncMs, 900000);
+    assert.equal(config.battle.l2SyncMsByProfile.production, 900000);
+    assert.equal(config.battle.l2SyncMsByProfile.soak, 600000);
     assert.equal(config.battle.maxBattleL1PerCycle, 60);
     assert.equal(config.battle.maxBattleL2PerCycle, 20);
     assert.equal(config.battle.candidateQuota, 0.30);
     assert.equal(config.battle.l3.enabled, true);
-    assert.equal(config.battle.l3.syncMs, 2700000);
+    assert.equal(config.battle.l3.syncMs, 1200000);
+    assert.equal(config.battle.l3.syncMsByProfile.production, 1200000);
+    assert.equal(config.battle.l3.syncMsByProfile.soak, 600000);
     assert.equal(config.battle.l3.maxPerCycle, 12);
     assert.equal(config.battle.l3.concurrency, 3);
-    assert.equal(config.battle.l3.timeoutMs, 12000);
-    assert.equal(config.battle.l3.allowedProtocols.includes('socks5'), true);
+    assert.equal(config.battle.l3.timeoutMs, 18000);
+    assert.deepEqual(config.battle.l3.allowedProtocols, ['http', 'https', 'socks5']);
+    assert.equal(config.battle.l3.targets.length >= 2, true);
     assert.equal(config.battle.l3.targets[0].url, 'https://www.ly.com/flights/home');
     assert.equal(config.failureBackoff.enabled, true);
     assert.equal(config.failureBackoff.maxMs, 21600000);
@@ -163,6 +171,31 @@ test('config should support battle l3 env overrides', { concurrency: false }, ()
     assert.equal(config.battle.l3.targets[0].name, 'l3-one');
 });
 
+test('config should use soak l3 sync default when soak profile is enabled', { concurrency: false }, () => {
+    const config = loadConfigWithEnv({
+        PROXY_HUB_POLICY_PROFILE: 'soak',
+    });
+    assert.equal(config.rollout.activeProfile, 'soak');
+    assert.equal(config.battle.l2SyncMs, 600000);
+    assert.equal(config.battle.l3.syncMs, 600000);
+});
+
+test('config should keep l3 sync env override higher priority than soak profile default', { concurrency: false }, () => {
+    const config = loadConfigWithEnv({
+        PROXY_HUB_POLICY_PROFILE: 'soak',
+        PROXY_HUB_BATTLE_L3_MS: '1234567',
+    });
+    assert.equal(config.battle.l3.syncMs, 1234567);
+});
+
+test('config should keep l2 sync env override higher priority than soak profile default', { concurrency: false }, () => {
+    const config = loadConfigWithEnv({
+        PROXY_HUB_POLICY_PROFILE: 'soak',
+        PROXY_HUB_BATTLE_L2_MS: '765432',
+    });
+    assert.equal(config.battle.l2SyncMs, 765432);
+});
+
 test('config should normalize battle l3 target and protocol env fallbacks', { concurrency: false }, () => {
     const config = loadConfigWithEnv({
         PROXY_HUB_BATTLE_L3_TARGETS_JSON: JSON.stringify([
@@ -175,6 +208,11 @@ test('config should normalize battle l3 target and protocol env fallbacks', { co
     assert.equal(config.battle.l3.targets.length, 2);
     assert.equal(config.battle.l3.targets[0].name, 'https://example.com/only-url');
     assert.deepEqual(config.battle.l3.allowedProtocols, ['https', 'socks5']);
+});
+
+test('config should include default l3 secondary browser target', { concurrency: false }, () => {
+    const config = loadConfigWithEnv();
+    assert.equal(config.battle.l3.targets.some((item) => item.name === 'baidu-browser' && item.url === 'https://www.baidu.com'), true);
 });
 
 test('config should support source override for line-based lists', { concurrency: false }, () => {

--- a/apps/proxy-pool-service/src/soak.js
+++ b/apps/proxy-pool-service/src/soak.js
@@ -46,6 +46,58 @@ function createSoakRuntime(options = {}) {
         nextPolicyActionIndex: 0,
     };
 
+    // 0137_resolvePositiveNumber_解析正数配置逻辑
+    function resolvePositiveNumber(value, fallback = 0) {
+        const parsed = Number(value);
+        if (Number.isFinite(parsed) && parsed > 0) {
+            return parsed;
+        }
+        return Number(fallback) || 0;
+    }
+
+    // 0138_buildSoakChildEnv_构建soak子进程环境变量逻辑
+    function buildSoakChildEnv() {
+        const childEnv = { ...process.env };
+        if (!String(childEnv.PROXY_HUB_POLICY_PROFILE || '').trim()) {
+            childEnv.PROXY_HUB_POLICY_PROFILE = 'soak';
+        }
+        return childEnv;
+    }
+
+    // 0139_resolveEffectiveBattleL3SyncMs_解析L3生效调度间隔逻辑
+    function resolveEffectiveBattleL3SyncMs(childEnv) {
+        const envSyncMs = resolvePositiveNumber(childEnv.PROXY_HUB_BATTLE_L3_MS, 0);
+        if (envSyncMs > 0) {
+            return envSyncMs;
+        }
+
+        const profile = String(childEnv.PROXY_HUB_POLICY_PROFILE).trim().toLowerCase();
+        const profileDefaults = config?.battle?.l3?.syncMsByProfile || {};
+        const profileSyncMs = resolvePositiveNumber(profileDefaults[profile], 0);
+        if (profileSyncMs > 0) {
+            return profileSyncMs;
+        }
+
+        return resolvePositiveNumber(config?.battle?.l3?.syncMs, 0);
+    }
+
+    // 0141_resolveEffectiveBattleL2SyncMs_解析L2生效调度间隔逻辑
+    function resolveEffectiveBattleL2SyncMs(childEnv) {
+        const envSyncMs = resolvePositiveNumber(childEnv.PROXY_HUB_BATTLE_L2_MS, 0);
+        if (envSyncMs > 0) {
+            return envSyncMs;
+        }
+
+        const profile = String(childEnv.PROXY_HUB_POLICY_PROFILE).trim().toLowerCase();
+        const profileDefaults = config?.battle?.l2SyncMsByProfile || {};
+        const profileSyncMs = resolvePositiveNumber(profileDefaults[profile], 0);
+        if (profileSyncMs > 0) {
+            return profileSyncMs;
+        }
+
+        return resolvePositiveNumber(config?.battle?.l2SyncMs, 0);
+    }
+
     // 0118_appendTimeline_执行appendTimeline相关逻辑
     function appendTimeline(type, data) {
         const line = JSON.stringify({ timestamp: now().toISOString(), type, ...data });
@@ -235,10 +287,17 @@ function createSoakRuntime(options = {}) {
             // start child process
         }
 
-        appendTimeline('service_start', { message: '未检测到服务，启动 proxyhub 进程' });
+        const childEnv = buildSoakChildEnv();
+        appendTimeline('service_start', {
+            message: '未检测到服务，启动 proxyhub 进程',
+            policyProfile: childEnv.PROXY_HUB_POLICY_PROFILE,
+            battleL2SyncMs: resolveEffectiveBattleL2SyncMs(childEnv),
+            battleL3SyncMs: resolveEffectiveBattleL3SyncMs(childEnv),
+        });
         state.child = spawnImpl(process.execPath, [pathImpl.join(__dirname, 'server.js')], {
             cwd: process.cwd(),
             stdio: ['ignore', 'pipe', 'pipe'],
+            env: childEnv,
         });
         state.childManaged = true;
         state.startedBySoak = true;
@@ -346,6 +405,18 @@ function createSoakRuntime(options = {}) {
     // 0123_runSoak_执行逻辑
     async function runSoak() {
         loadPolicyActions();
+        const childEnv = buildSoakChildEnv();
+        const battleL1SyncMs = resolvePositiveNumber(
+            process.env.PROXY_HUB_BATTLE_L1_MS,
+            resolvePositiveNumber(config?.battle?.l1SyncMs, 0),
+        );
+        appendTimeline('effective_schedule', {
+            policyProfile: childEnv.PROXY_HUB_POLICY_PROFILE,
+            battleL1SyncMs,
+            battleL2SyncMs: resolveEffectiveBattleL2SyncMs(childEnv),
+            battleL3SyncMs: resolveEffectiveBattleL3SyncMs(childEnv),
+            battleL3SyncSource: String(childEnv.PROXY_HUB_BATTLE_L3_MS || '').trim() ? 'env' : 'profile_default',
+        });
         appendTimeline('soak_start', {
             durationHours,
             pollMs,

--- a/apps/proxy-pool-service/src/soak.test.js
+++ b/apps/proxy-pool-service/src/soak.test.js
@@ -23,6 +23,21 @@ async function withTempCwd(fn) {
 function makeConfig() {
     return {
         service: { port: 5070 },
+        battle: {
+            l1SyncMs: 300000,
+            l2SyncMs: 1800000,
+            l2SyncMsByProfile: {
+                production: 1800000,
+                soak: 600000,
+            },
+            l3: {
+                syncMs: 2700000,
+                syncMsByProfile: {
+                    production: 2700000,
+                    soak: 600000,
+                },
+            },
+        },
         soak: { durationHours: 10, summaryIntervalMs: 3600000 },
         policy: {
             promotionProtectHours: 6,
@@ -49,6 +64,15 @@ function makeChild() {
         child.killSignal = signal;
     };
     return child;
+}
+
+// 0140_restoreEnvVar_恢复环境变量逻辑
+function restoreEnvVar(key, value) {
+    if (value == null) {
+        delete process.env[key];
+        return;
+    }
+    process.env[key] = value;
 }
 
 test('soak runtime should detect existing service without spawning', async () => {
@@ -78,25 +102,101 @@ test('soak runtime should spawn service and mark ready', async () => {
     await withTempCwd(async () => {
         const child = makeChild();
         let fetchCalls = 0;
-        const runtime = createSoakRuntime({
-            config: makeConfig(),
-            fetchImpl: async () => {
-                fetchCalls += 1;
-                if (fetchCalls < 2) {
-                    throw new Error('down');
-                }
-                return { ok: true, status: 200, async json() { return { ok: true, poolStatus: { queueSize: 0, workersBusy: 0, workersTotal: 1, failedTasks: 0, restartedWorkers: 0, completedTasks: 0 } }; } };
-            },
-            spawnImpl: () => child,
-        });
+        let spawnOptions = null;
+        const oldProfile = process.env.PROXY_HUB_POLICY_PROFILE;
+        try {
+            delete process.env.PROXY_HUB_POLICY_PROFILE;
+            const runtime = createSoakRuntime({
+                config: makeConfig(),
+                fetchImpl: async () => {
+                    fetchCalls += 1;
+                    if (fetchCalls < 2) {
+                        throw new Error('down');
+                    }
+                    return { ok: true, status: 200, async json() { return { ok: true, poolStatus: { queueSize: 0, workersBusy: 0, workersTotal: 1, failedTasks: 0, restartedWorkers: 0, completedTasks: 0 } }; } };
+                },
+                spawnImpl: (_cmd, _args, options) => {
+                    spawnOptions = options;
+                    return child;
+                },
+            });
 
-        await runtime.ensureService();
-        child.stdout.emit('data', Buffer.from('hello'));
-        child.stderr.emit('data', Buffer.from('oops'));
-        child.emit('exit', 0, null);
+            await runtime.ensureService();
+            child.stdout.emit('data', Buffer.from('hello'));
+            child.stderr.emit('data', Buffer.from('oops'));
+            child.emit('exit', 0, null);
 
-        assert.equal(runtime.state.childManaged, true);
-        assert.equal(runtime.state.crashCount, 1);
+            assert.equal(runtime.state.childManaged, true);
+            assert.equal(runtime.state.crashCount, 1);
+            assert.equal(spawnOptions.env.PROXY_HUB_POLICY_PROFILE, 'soak');
+        } finally {
+            restoreEnvVar('PROXY_HUB_POLICY_PROFILE', oldProfile);
+        }
+    });
+});
+
+test('ensureService should keep explicit policy profile when spawning child process', async () => {
+    await withTempCwd(async () => {
+        const child = makeChild();
+        let fetchCalls = 0;
+        let spawnOptions = null;
+        const oldProfile = process.env.PROXY_HUB_POLICY_PROFILE;
+        try {
+            process.env.PROXY_HUB_POLICY_PROFILE = 'production';
+            const runtime = createSoakRuntime({
+                config: makeConfig(),
+                fetchImpl: async () => {
+                    fetchCalls += 1;
+                    if (fetchCalls < 2) {
+                        throw new Error('down');
+                    }
+                    return { ok: true, status: 200, async json() { return { ok: true }; } };
+                },
+                spawnImpl: (_cmd, _args, options) => {
+                    spawnOptions = options;
+                    return child;
+                },
+            });
+            await runtime.ensureService();
+            assert.equal(spawnOptions.env.PROXY_HUB_POLICY_PROFILE, 'production');
+        } finally {
+            restoreEnvVar('PROXY_HUB_POLICY_PROFILE', oldProfile);
+        }
+    });
+});
+
+test('ensureService should prefer explicit L2/L3 sync env values in service_start timeline', async () => {
+    await withTempCwd(async () => {
+        const child = makeChild();
+        let fetchCalls = 0;
+        const oldProfile = process.env.PROXY_HUB_POLICY_PROFILE;
+        const oldL2 = process.env.PROXY_HUB_BATTLE_L2_MS;
+        const oldL3 = process.env.PROXY_HUB_BATTLE_L3_MS;
+        try {
+            delete process.env.PROXY_HUB_POLICY_PROFILE;
+            process.env.PROXY_HUB_BATTLE_L2_MS = '321000';
+            process.env.PROXY_HUB_BATTLE_L3_MS = '654000';
+            const runtime = createSoakRuntime({
+                config: makeConfig(),
+                fetchImpl: async () => {
+                    fetchCalls += 1;
+                    if (fetchCalls < 2) {
+                        throw new Error('down');
+                    }
+                    return { ok: true, status: 200, async json() { return { ok: true }; } };
+                },
+                spawnImpl: () => child,
+            });
+
+            await runtime.ensureService();
+            const timeline = fs.readFileSync(runtime.timelineFile, 'utf8');
+            assert.equal(timeline.includes('"battleL2SyncMs":321000'), true);
+            assert.equal(timeline.includes('"battleL3SyncMs":654000'), true);
+        } finally {
+            restoreEnvVar('PROXY_HUB_POLICY_PROFILE', oldProfile);
+            restoreEnvVar('PROXY_HUB_BATTLE_L2_MS', oldL2);
+            restoreEnvVar('PROXY_HUB_BATTLE_L3_MS', oldL3);
+        }
     });
 });
 
@@ -393,12 +493,121 @@ test('runSoak should complete loop, write report, and kill child when managed', 
         assert.equal(child.killSignal, 'SIGTERM');
         assert.equal(runtime.state.policyActionsApplied, 1);
         assert.equal(runtime.state.lastValueBoard.length, 1);
+        const timeline = fs.readFileSync(result.timelineFile, 'utf8');
+        assert.equal(timeline.includes('"type":"effective_schedule"'), true);
+        assert.equal(timeline.includes('"battleL2SyncMs":600000'), true);
+        assert.equal(timeline.includes('"battleL3SyncMs":600000'), true);
 
         Date.now = oldNow;
         process.env.SOAK_HOURS = oldEnv.SOAK_HOURS;
         process.env.SOAK_POLL_MS = oldEnv.SOAK_POLL_MS;
         process.env.SOAK_SUMMARY_MS = oldEnv.SOAK_SUMMARY_MS;
         process.env.SOAK_POLICY_ACTIONS_FILE = oldEnv.SOAK_POLICY_ACTIONS_FILE;
+    });
+});
+
+test('runSoak should fallback L2/L3 schedule to config defaults when profile maps are missing', async () => {
+    await withTempCwd(async () => {
+        const oldHours = process.env.SOAK_HOURS;
+        const oldPolicyFile = process.env.SOAK_POLICY_ACTIONS_FILE;
+        const oldProfile = process.env.PROXY_HUB_POLICY_PROFILE;
+        const oldL2 = process.env.PROXY_HUB_BATTLE_L2_MS;
+        const oldL3 = process.env.PROXY_HUB_BATTLE_L3_MS;
+        try {
+            process.env.SOAK_HOURS = '0';
+            process.env.SOAK_POLICY_ACTIONS_FILE = '';
+            process.env.PROXY_HUB_POLICY_PROFILE = 'staging';
+            delete process.env.PROXY_HUB_BATTLE_L2_MS;
+            delete process.env.PROXY_HUB_BATTLE_L3_MS;
+            const runtime = createSoakRuntime({
+                config: {
+                    ...makeConfig(),
+                    battle: {
+                        l1SyncMs: 300000,
+                        l2SyncMs: 1110000,
+                        l3: {
+                            syncMs: 2220000,
+                        },
+                    },
+                },
+                fetchImpl: async (url) => {
+                    if (url.endsWith('/health')) {
+                        return { ok: true, status: 200, async json() { return { ok: true }; } };
+                    }
+                    if (url.includes('/v1/proxies/value-board')) {
+                        return { ok: true, status: 200, async json() { return { items: [] }; } };
+                    }
+                    return {
+                        ok: true,
+                        status: 200,
+                        async json() {
+                            return { poolStatus: { queueSize: 0, workersBusy: 0, workersTotal: 1, failedTasks: 0, restartedWorkers: 0, completedTasks: 0 } };
+                        },
+                    };
+                },
+            });
+            await runtime.runSoak();
+            const timeline = fs.readFileSync(runtime.timelineFile, 'utf8');
+            assert.equal(timeline.includes('"battleL2SyncMs":1110000'), true);
+            assert.equal(timeline.includes('"battleL3SyncMs":2220000'), true);
+        } finally {
+            restoreEnvVar('SOAK_HOURS', oldHours);
+            restoreEnvVar('SOAK_POLICY_ACTIONS_FILE', oldPolicyFile);
+            restoreEnvVar('PROXY_HUB_POLICY_PROFILE', oldProfile);
+            restoreEnvVar('PROXY_HUB_BATTLE_L2_MS', oldL2);
+            restoreEnvVar('PROXY_HUB_BATTLE_L3_MS', oldL3);
+        }
+    });
+});
+
+test('runSoak should mark env schedule source and apply explicit L1/L2/L3 sync env values', async () => {
+    await withTempCwd(async () => {
+        const oldHours = process.env.SOAK_HOURS;
+        const oldPolicyFile = process.env.SOAK_POLICY_ACTIONS_FILE;
+        const oldProfile = process.env.PROXY_HUB_POLICY_PROFILE;
+        const oldL1 = process.env.PROXY_HUB_BATTLE_L1_MS;
+        const oldL2 = process.env.PROXY_HUB_BATTLE_L2_MS;
+        const oldL3 = process.env.PROXY_HUB_BATTLE_L3_MS;
+        try {
+            process.env.SOAK_HOURS = '0';
+            process.env.SOAK_POLICY_ACTIONS_FILE = '';
+            delete process.env.PROXY_HUB_POLICY_PROFILE;
+            process.env.PROXY_HUB_BATTLE_L1_MS = '123000';
+            process.env.PROXY_HUB_BATTLE_L2_MS = '234000';
+            process.env.PROXY_HUB_BATTLE_L3_MS = '345000';
+
+            const runtime = createSoakRuntime({
+                config: makeConfig(),
+                fetchImpl: async (url) => {
+                    if (url.endsWith('/health')) {
+                        return { ok: true, status: 200, async json() { return { ok: true }; } };
+                    }
+                    if (url.includes('/v1/proxies/value-board')) {
+                        return { ok: true, status: 200, async json() { return { items: [] }; } };
+                    }
+                    return {
+                        ok: true,
+                        status: 200,
+                        async json() {
+                            return { poolStatus: { queueSize: 0, workersBusy: 0, workersTotal: 1, failedTasks: 0, restartedWorkers: 0, completedTasks: 0 } };
+                        },
+                    };
+                },
+            });
+            await runtime.runSoak();
+            const timeline = fs.readFileSync(runtime.timelineFile, 'utf8');
+            assert.equal(timeline.includes('"battleL1SyncMs":123000'), true);
+            assert.equal(timeline.includes('"battleL2SyncMs":234000'), true);
+            assert.equal(timeline.includes('"battleL3SyncMs":345000'), true);
+            assert.equal(timeline.includes('"battleL3SyncSource":"env"'), true);
+        } finally {
+            restoreEnvVar('SOAK_HOURS', oldHours);
+            restoreEnvVar('SOAK_POLICY_ACTIONS_FILE', oldPolicyFile);
+            restoreEnvVar('PROXY_HUB_POLICY_PROFILE', oldProfile);
+            restoreEnvVar('PROXY_HUB_BATTLE_L1_MS', oldL1);
+            restoreEnvVar('PROXY_HUB_BATTLE_L2_MS', oldL2);
+            restoreEnvVar('PROXY_HUB_BATTLE_L3_MS', oldL3);
+        }
     });
 });
 


### PR DESCRIPTION
## Summary
- align L2/L3 default schedules by policy profile (`production` vs `soak`) in config
- keep env override priority (`PROXY_HUB_BATTLE_L2_MS/PROXY_HUB_BATTLE_L3_MS`) above profile defaults
- make soak child process default to `PROXY_HUB_POLICY_PROFILE=soak` unless already explicitly set
- append `effective_schedule` timeline fields for L1/L2/L3 effective sync values and L3 source
- restore L3 default protocols to include `socks5`
- add/extend config + soak tests for profile defaults, env override priority, and timeline assertions

## Verification
- `node --test apps/proxy-pool-service/src/config.test.js`
- `node --test apps/proxy-pool-service/src/soak.test.js`
- `npm.cmd run test:proxyhub:unit`
- `npm.cmd run test:proxyhub:coverage`
  - Statements: 100%
  - Branches: 98.06%
  - Functions: 100%
  - Lines: 100%

Closes #83