### PR TITLE
tune(proxyhub): raise l3 timeout to 40s with 120s worker timeout

### DIFF
--- a/apps/proxy-pool-service/src/config.js
+++ b/apps/proxy-pool-service/src/config.js
@@ -442,7 +442,7 @@ module.exports = {
     },
     threadPool: {
         workers: Number(process.env.PROXY_HUB_WORKERS || 6),
-        taskTimeoutMs: 90_000,
+        taskTimeoutMs: 120_000,
     },
     scheduler: {
         sourceSyncMs: Number(process.env.PROXY_HUB_SOURCE_SYNC_MS || 120_000),
@@ -515,7 +515,7 @@ module.exports = {
             maxPerCycle: Number(process.env.PROXY_HUB_BATTLE_L3_MAX || 12),
             concurrency: Number(process.env.PROXY_HUB_BATTLE_L3_CONCURRENCY || 3),
             lookbackMinutes: Number(process.env.PROXY_HUB_BATTLE_L3_LOOKBACK_MINUTES || l2LookbackByProfile[activeProfile]),
-            timeoutMs: Number(process.env.PROXY_HUB_BATTLE_L3_TIMEOUT_MS || 30_000),
+            timeoutMs: Number(process.env.PROXY_HUB_BATTLE_L3_TIMEOUT_MS || 40_000),
             allowedProtocols: deepClone(resolvedBattleL3Protocols),
             targets: deepClone(resolvedBattleL3Targets),
             syncMsByProfile: deepClone(battleL3SyncMsByProfile),

--- a/apps/proxy-pool-service/src/config.test.js
+++ b/apps/proxy-pool-service/src/config.test.js
@@ -87,7 +87,7 @@ test('config should expose required default values', { concurrency: false }, () 
     assert.equal(config.service.port, 5070);
     assert.equal(config.service.timezone, 'Asia/Shanghai');
     assert.equal(config.threadPool.workers > 0, true);
-    assert.equal(config.threadPool.taskTimeoutMs, 90000);
+    assert.equal(config.threadPool.taskTimeoutMs, 120000);
     assert.equal(Array.isArray(config.validation.allowedProtocols), true);
     assert.equal(config.source.activeProfile, 'speedx_bundle');
     assert.equal(config.source.legacySingleOverride, false);
@@ -115,7 +115,7 @@ test('config should expose required default values', { concurrency: false }, () 
     assert.equal(config.battle.l3.syncMsByProfile.soak, 600000);
     assert.equal(config.battle.l3.maxPerCycle, 12);
     assert.equal(config.battle.l3.concurrency, 3);
-    assert.equal(config.battle.l3.timeoutMs, 30000);
+    assert.equal(config.battle.l3.timeoutMs, 40000);
     assert.deepEqual(config.battle.l3.allowedProtocols, ['http', 'https', 'socks5']);
     assert.equal(config.battle.l3.targets.length >= 2, true);
     assert.equal(config.battle.l3.targets[0].url, 'https://www.ly.com/flights/home');


### PR DESCRIPTION
## Summary
- raise default L3 browser timeout to `40000ms` (from 30000ms)
- raise worker-pool task timeout to `120000ms` (from 90000ms) to avoid premature timeout for serial L3 browser targets
- update config unit assertions for the new defaults

## Validation
- `node --test apps/proxy-pool-service/src/config.test.js`
- `npm.cmd run test:proxyhub:unit`
- `npm.cmd run test:proxyhub:coverage`
  - Statements: 100%
  - Branches: 98.06%
  - Functions: 100%
  - Lines: 100%

Closes #88