### PR TITLE
feat(proxyhub): #90 籍贯JSON中文化与统一格式化

### DIFF
--- a/apps/proxy-pool-service/src/db.js
+++ b/apps/proxy-pool-service/src/db.js
@@ -74,6 +74,7 @@ class ProxyHubDb {
                 native_lookup_status TEXT NOT NULL DEFAULT 'pending',
                 native_next_retry_at TEXT,
                 native_lookup_raw_json TEXT,
+                native_lookup_readable_text TEXT,
                 service_hours REAL NOT NULL DEFAULT 0,
                 rank_service_hours REAL NOT NULL DEFAULT 0,
                 combat_points INTEGER NOT NULL DEFAULT 0,
@@ -333,6 +334,7 @@ class ProxyHubDb {
             { name: 'native_lookup_status', sql: "TEXT NOT NULL DEFAULT 'pending'" },
             { name: 'native_next_retry_at', sql: 'TEXT' },
             { name: 'native_lookup_raw_json', sql: 'TEXT' },
+            { name: 'native_lookup_readable_text', sql: 'TEXT' },
         ];
 
         for (const column of requiredColumns) {
@@ -1147,7 +1149,7 @@ class ProxyHubDb {
             SELECT id, display_name, ip, port, protocol, source, lifecycle, rank,
                 service_branch, branch_fail_streak,
                 native_place, native_country, native_city, native_provider, native_resolved_at,
-                native_lookup_status, native_next_retry_at, native_lookup_raw_json,
+                native_lookup_status, native_next_retry_at, native_lookup_raw_json, native_lookup_readable_text,
                 service_hours, rank_service_hours, combat_points, health_score, discipline_score,
                 success_count, block_count, timeout_count, network_error_count,
                 total_samples, retired_type, is_applied, updated_at, last_checked_at,
@@ -1212,7 +1214,7 @@ class ProxyHubDb {
                 p.service_branch,
                 p.native_place, p.native_country, p.native_city, p.native_provider,
                 p.native_resolved_at, p.native_lookup_status, p.native_next_retry_at,
-                p.native_lookup_raw_json,
+                p.native_lookup_raw_json, p.native_lookup_readable_text,
                 p.ip_value_score, p.ip_value_breakdown_json,
                 p.combat_points, p.health_score, p.discipline_score,
                 p.success_count, p.total_samples, p.battle_success_count, p.battle_fail_count,

--- a/apps/proxy-pool-service/src/db.test.js
+++ b/apps/proxy-pool-service/src/db.test.js
@@ -265,6 +265,7 @@ test('query list APIs should support filters and distributions', () => {
     assert.equal(Object.prototype.hasOwnProperty.call(all[0], 'native_place'), true);
     assert.equal(Object.prototype.hasOwnProperty.call(all[0], 'native_lookup_status'), true);
     assert.equal(Object.prototype.hasOwnProperty.call(all[0], 'native_lookup_raw_json'), true);
+    assert.equal(Object.prototype.hasOwnProperty.call(all[0], 'native_lookup_readable_text'), true);
     assert.equal(all[0].service_branch, '陆军');
     assert.equal(all[0].branch_fail_streak, 0);
     assert.equal(all[0].native_place, '未知');
@@ -562,6 +563,7 @@ test('value board API should sort by value and parse breakdown and honor fields'
         native_provider: 'ipapi.co',
         native_lookup_status: 'resolved',
         native_lookup_raw_json: '{"status":"success","country":"中国","city":"北京"}',
+        native_lookup_readable_text: '国家(country): "中国"\n城市(city): "北京"',
         updated_at: now,
     });
 
@@ -661,6 +663,7 @@ test('value board API should sort by value and parse breakdown and honor fields'
     assert.equal(board[1].native_place, '中国-北京');
     assert.equal(board[1].native_lookup_status, 'resolved');
     assert.equal(board[1].native_lookup_raw_json.includes('"country":"中国"'), true);
+    assert.equal(board[1].native_lookup_readable_text.includes('国家(country)'), true);
 
     const filtered = h.db.getValueBoard(10, 'active');
     assert.equal(filtered.length, 1);
@@ -1176,6 +1179,7 @@ test('ensureProxyColumns should add missing columns in legacy schema', () => {
     ProxyHubDb.prototype.ensureProxyColumns.call(fake);
     assert.equal(execCalls.length > 0, true);
     assert.equal(execCalls.every((sql) => sql.includes('ALTER TABLE proxies ADD COLUMN')), true);
+    assert.equal(execCalls.some((sql) => sql.includes('native_lookup_readable_text')), true);
 });
 
 // 0217_createNameGenerator_创建迁移姓名生成器逻辑

--- a/apps/proxy-pool-service/src/engine.js
+++ b/apps/proxy-pool-service/src/engine.js
@@ -426,6 +426,114 @@ function normalizeNativeReason(value, fallback = 'request-failed') {
     return normalized || fallback;
 }
 
+const NATIVE_LOOKUP_READABLE_LABELS = {
+    ip: 'IP地址(ip)',
+    network: '网络段(network)',
+    version: 'IP版本(version)',
+    city: '城市(city)',
+    region: '地区(region)',
+    region_code: '地区代码(region_code)',
+    country: '国家(country)',
+    country_name: '国家(country_name)',
+    country_code: '国家代码(country_code)',
+    country_code_iso3: '国家三字码(country_code_iso3)',
+    country_capital: '首都(country_capital)',
+    country_tld: '国家域名后缀(country_tld)',
+    continent_code: '洲代码(continent_code)',
+    in_eu: '是否欧盟(in_eu)',
+    postal: '邮编(postal)',
+    latitude: '纬度(latitude)',
+    longitude: '经度(longitude)',
+    timezone: '时区(timezone)',
+    utc_offset: 'UTC偏移(utc_offset)',
+    country_calling_code: '国家区号(country_calling_code)',
+    currency: '货币代码(currency)',
+    currency_name: '货币名称(currency_name)',
+    languages: '语言(languages)',
+    country_area: '国家面积(country_area)',
+    country_population: '国家人口(country_population)',
+    asn: 'ASN(asn)',
+    org: '组织(org)',
+    isp: '网络归属(isp)',
+    countryName: '国家(countryName)',
+    countryCode: '国家代码(countryCode)',
+    cityName: '城市(cityName)',
+    regionName: '地区(regionName)',
+    latitudeLongitudeAccuracyRadius: '定位精度半径(latitudeLongitudeAccuracyRadius)',
+    isProxy: '代理标记(isProxy)',
+    error: '错误(error)',
+    reason: '原因(reason)',
+    message: '消息(message)',
+};
+
+// 0291_stableSortJsonValue_稳定排序JSON值逻辑
+function stableSortJsonValue(value) {
+    if (Array.isArray(value)) {
+        return value.map((item) => stableSortJsonValue(item));
+    }
+    if (!value || typeof value !== 'object') {
+        return value;
+    }
+    const sortedKeys = Object.keys(value).sort((a, b) => a.localeCompare(b));
+    const result = {};
+    for (const key of sortedKeys) {
+        result[key] = stableSortJsonValue(value[key]);
+    }
+    return result;
+}
+
+// 0292_parseJsonPayloadLoose_宽松解析JSON载荷逻辑
+function parseJsonPayloadLoose(rawText, fallbackValue) {
+    const text = String(rawText == null ? '' : rawText).trim();
+    if (text.length > 0) {
+        try {
+            return JSON.parse(text);
+        } catch {
+            return fallbackValue;
+        }
+    }
+    return fallbackValue;
+}
+
+// 0293_normalizeNativeRawJson_规范化籍贯原始JSON逻辑
+function normalizeNativeRawJson(rawText, payload) {
+    const parsed = parseJsonPayloadLoose(rawText, payload);
+    if (parsed === undefined) {
+        return String(rawText == null ? '' : rawText);
+    }
+    return JSON.stringify(stableSortJsonValue(parsed), null, 2);
+}
+
+// 0294_formatNativeReadableValue_格式化籍贯可读值逻辑
+function formatNativeReadableValue(value) {
+    if (value === undefined) {
+        return 'null';
+    }
+    return JSON.stringify(stableSortJsonValue(value));
+}
+
+// 0295_buildNativeLookupReadableText_构建籍贯可读文本逻辑
+function buildNativeLookupReadableText(payload) {
+    if (payload && typeof payload === 'object' && !Array.isArray(payload)) {
+        const sorted = stableSortJsonValue(payload);
+        const keys = Object.keys(sorted);
+        if (keys.length === 0) {
+            return '原文不可解析';
+        }
+        return keys.map((key) => {
+            const label = NATIVE_LOOKUP_READABLE_LABELS[key] || `原键名(${key})`;
+            return `${label}: ${formatNativeReadableValue(sorted[key])}`;
+        }).join('\n');
+    }
+    if (Array.isArray(payload)) {
+        return `原键名(root): ${JSON.stringify(stableSortJsonValue(payload))}`;
+    }
+    if (payload == null) {
+        return '原文不可解析';
+    }
+    return `原键名(root): ${JSON.stringify(payload)}`;
+}
+
 const NATIVE_LOOKUP_PROVIDER_CHAIN = ['ipapi.co', 'freeipapi'];
 const NATIVE_LOOKUP_PROVIDER_CHAIN_LABEL = NATIVE_LOOKUP_PROVIDER_CHAIN.join(',');
 
@@ -605,12 +713,14 @@ class ProxyHubEngine extends EventEmitter {
 
         const country = String(payload?.country_name || payload?.country || '').trim() || '未知';
         const city = String(payload?.city || '').trim() || '未知';
+        const normalizedRawJson = normalizeNativeRawJson(rawJson, payload);
         return {
             provider: 'ipapi.co',
             country,
             city,
             place: `${country}-${city}`,
-            rawJson: rawJson || JSON.stringify(payload),
+            rawJson: normalizedRawJson,
+            readableText: buildNativeLookupReadableText(payload),
         };
     }
 
@@ -645,12 +755,14 @@ class ProxyHubEngine extends EventEmitter {
 
         const country = String(payload?.countryName || payload?.country_name || payload?.country || '').trim() || '未知';
         const city = String(payload?.cityName || payload?.city || '').trim() || '未知';
+        const normalizedRawJson = normalizeNativeRawJson(rawJson, payload);
         return {
             provider: 'freeipapi',
             country,
             city,
             place: `${country}-${city}`,
-            rawJson: rawJson || JSON.stringify(payload),
+            rawJson: normalizedRawJson,
+            readableText: buildNativeLookupReadableText(payload),
         };
     }
 
@@ -715,6 +827,7 @@ class ProxyHubEngine extends EventEmitter {
                 native_lookup_status: 'resolved',
                 native_next_retry_at: null,
                 native_lookup_raw_json: resolved.rawJson,
+                native_lookup_readable_text: resolved.readableText,
                 updated_at: nowIso,
             });
             const updatedProxy = this.db.getProxyById(proxyId) || proxy;
@@ -1900,6 +2013,9 @@ module.exports = {
     readNativeLookupConfig,
     isNativeRetryDue,
     normalizeNativeLookupStatus,
+    stableSortJsonValue,
+    normalizeNativeRawJson,
+    buildNativeLookupReadableText,
     ProxyHubEngine,
 };
 

--- a/apps/proxy-pool-service/src/engine.test.js
+++ b/apps/proxy-pool-service/src/engine.test.js
@@ -21,6 +21,9 @@ const {
     readNativeLookupConfig,
     isNativeRetryDue,
     normalizeNativeLookupStatus,
+    stableSortJsonValue,
+    normalizeNativeRawJson,
+    buildNativeLookupReadableText,
     ProxyHubEngine,
 } = require('./engine');
 
@@ -274,6 +277,30 @@ test('engine utility functions should cover helper branches', async () => {
     assert.equal(normalizeNativeLookupStatus('resolved'), 'resolved');
     assert.equal(normalizeNativeLookupStatus('bad-value'), 'pending');
     assert.equal(normalizeNativeLookupStatus(null), 'pending');
+    assert.deepEqual(stableSortJsonValue({
+        z: 1,
+        a: {
+            d: 4,
+            c: [3, { y: 2, x: 1 }],
+        },
+    }), {
+        a: {
+            c: [3, { x: 1, y: 2 }],
+            d: 4,
+        },
+        z: 1,
+    });
+    assert.equal(normalizeNativeRawJson('{"b":2,"a":1}', null), '{\n  "a": 1,\n  "b": 2\n}');
+    assert.equal(normalizeNativeRawJson('{bad-json', { b: 2, a: 1 }), '{\n  "a": 1,\n  "b": 2\n}');
+    assert.equal(normalizeNativeRawJson('', undefined), '');
+    assert.equal(buildNativeLookupReadableText({ org: 'ORG', isp: 'ISP', custom: 1 }).includes('网络归属(isp): "ISP"'), true);
+    assert.equal(buildNativeLookupReadableText({ org: 'ORG', isp: 'ISP', custom: 1 }).includes('组织(org): "ORG"'), true);
+    assert.equal(buildNativeLookupReadableText({ org: 'ORG', isp: 'ISP', custom: 1 }).includes('原键名(custom): 1'), true);
+    assert.equal(buildNativeLookupReadableText({ missing: undefined }).includes('原键名(missing): null'), true);
+    assert.equal(buildNativeLookupReadableText({}), '原文不可解析');
+    assert.equal(buildNativeLookupReadableText(['x']), '原键名(root): ["x"]');
+    assert.equal(buildNativeLookupReadableText(null), '原文不可解析');
+    assert.equal(buildNativeLookupReadableText('x'), '原键名(root): "x"');
     const disabledPolicy = readBranchingConfig({ branching: { enabled: false } });
     assert.equal(disabledPolicy.enabled, false);
     const normalizedPolicy = readBranchingConfig({
@@ -1518,6 +1545,7 @@ test('applyCombatOutcome should resolve native place asynchronously for target b
         city: '北京',
         place: '中国-北京',
         rawJson: '{"status":"success","country":"中国","city":"北京"}',
+        readableText: '国家(country): "中国"\n城市(city): "北京"',
     });
 
     await engine.applyCombatOutcome({
@@ -1536,7 +1564,8 @@ test('applyCombatOutcome should resolve native place asynchronously for target b
     assert.equal(updated.service_branch, '海军');
     assert.equal(updated.native_place, '中国-北京');
     assert.equal(updated.native_provider, 'ipapi.co');
-    assert.equal(updated.native_lookup_raw_json.includes('"country":"中国"'), true);
+    assert.equal(JSON.parse(updated.native_lookup_raw_json).country, '中国');
+    assert.equal(updated.native_lookup_readable_text.includes('国家(country)'), true);
     assert.equal(h.db.getEvents(30).some((item) => item.event_type === 'native_lookup_resolved'), true);
     assert.equal(logger.entries.some((item) => item.event === '籍贯解析成功'), true);
 
@@ -1650,6 +1679,7 @@ test('applyCombatOutcome should skip non-target branch and honor native retry wi
             city: '广州',
             place: '中国-广州',
             rawJson: '{"status":"success","country":"中国","city":"广州"}',
+            readableText: '国家(country): "中国"\n城市(city): "广州"',
         };
     };
 
@@ -1933,10 +1963,8 @@ test('resolveNativePlaceByIp should use ipapi.co first and fallback to freeipapi
         });
         const ipapiRawFallback = await engine.resolveNativePlaceByIpapiCo('5.5.5.82', 900);
         assert.equal(ipapiRawFallback.place, '法国-巴黎');
-        assert.equal(
-            ipapiRawFallback.rawJson,
-            JSON.stringify({ country: '法国', city: '巴黎' }),
-        );
+        assert.deepEqual(JSON.parse(ipapiRawFallback.rawJson), { country: '法国', city: '巴黎' });
+        assert.equal(ipapiRawFallback.readableText.includes('国家(country)'), true);
 
         JSON.parse = oldJsonParse;
         global.fetch = async () => ({
@@ -1999,10 +2027,8 @@ test('resolveNativePlaceByIp should use ipapi.co first and fallback to freeipapi
         };
         const fallbackRawResolved = await engine.resolveNativePlaceByIp('5.5.5.10', 900);
         assert.equal(fallbackRawResolved.place, '墨西哥-蒙特雷');
-        assert.equal(
-            fallbackRawResolved.rawJson,
-            JSON.stringify({ country_name: '墨西哥', city: '蒙特雷' }),
-        );
+        assert.deepEqual(JSON.parse(fallbackRawResolved.rawJson), { country_name: '墨西哥', city: '蒙特雷' });
+        assert.equal(fallbackRawResolved.readableText.includes('国家(country_name)'), true);
 
         const oldResolveIpapiCo = engine.resolveNativePlaceByIpapiCo.bind(engine);
         const oldResolveFreeipapi = engine.resolveNativePlaceByFreeipapi.bind(engine);
@@ -2150,6 +2176,7 @@ test('native lookup decision/task/schedule helpers should cover edge branches', 
             city: '广州',
             place: '中国-广州',
             rawJson: '{"status":"success"}',
+            readableText: '原键名(status): "success"',
         };
     };
     await engine.runNativeLookupTask(proxy.id, 'src');
@@ -2274,6 +2301,7 @@ test('native lookup should fallback to cached proxy when db row disappears and d
                 city: '成都',
                 place: '中国-成都',
                 rawJson: '{"status":"success","country":"中国","city":"成都"}',
+                readableText: '国家(country): "中国"\n城市(city): "成都"',
             };
         }
         throw new Error(`unexpected-ip-${ip}`);

--- a/apps/proxy-pool-service/src/migrate-native-lookup-json-format.js
+++ b/apps/proxy-pool-service/src/migrate-native-lookup-json-format.js
@@ -1,0 +1,218 @@
+const config = require('./config');
+const { ProxyHubDb } = require('./db');
+const {
+    normalizeNativeRawJson,
+    buildNativeLookupReadableText,
+} = require('./engine');
+
+// 0296_parseArgs_parse migration args
+function parseArgs(argv) {
+    const args = Array.isArray(argv) ? argv : [];
+    let dryRun = true;
+    let sample = 20;
+    let limit = 0;
+
+    for (let i = 0; i < args.length; i += 1) {
+        const arg = args[i];
+        if (arg === '--apply') {
+            dryRun = false;
+            continue;
+        }
+        if (arg === '--dry-run') {
+            dryRun = true;
+            continue;
+        }
+        if (arg === '--sample') {
+            const value = Number(args[i + 1]);
+            if (!Number.isFinite(value) || value <= 0) {
+                throw new Error('invalid-sample-value');
+            }
+            sample = Math.max(1, Math.min(200, Math.floor(value)));
+            i += 1;
+            continue;
+        }
+        if (arg === '--limit') {
+            const value = Number(args[i + 1]);
+            if (!Number.isFinite(value) || value < 0) {
+                throw new Error('invalid-limit-value');
+            }
+            limit = Math.floor(value);
+            i += 1;
+            continue;
+        }
+        throw new Error(`unknown-arg:${arg}`);
+    }
+
+    return { dryRun, sample, limit };
+}
+
+// 0297_tryParseJson_try parse raw json text
+function tryParseJson(rawJson) {
+    const text = String(rawJson == null ? '' : rawJson).trim();
+    if (text.length === 0) {
+        return {
+            ok: false,
+            reason: 'empty',
+            value: undefined,
+            text,
+        };
+    }
+    try {
+        return {
+            ok: true,
+            reason: 'parsed',
+            value: JSON.parse(text),
+            text,
+        };
+    } catch {
+        return {
+            ok: false,
+            reason: 'invalid-json',
+            value: undefined,
+            text,
+        };
+    }
+}
+
+// 0298_buildMigrationRow_build migrated row payload
+function buildMigrationRow(row) {
+    const id = Number(row?.id);
+    const rawBefore = String(row?.native_lookup_raw_json == null ? '' : row.native_lookup_raw_json);
+    const readableBefore = String(row?.native_lookup_readable_text == null ? '' : row.native_lookup_readable_text);
+    const parsed = tryParseJson(rawBefore);
+    if (parsed.reason === 'empty') {
+        return null;
+    }
+
+    if (parsed.ok) {
+        const rawAfter = normalizeNativeRawJson(parsed.text, parsed.value);
+        const readableAfter = buildNativeLookupReadableText(parsed.value);
+        return {
+            id,
+            parseStatus: 'parsed',
+            changed: rawAfter !== rawBefore || readableAfter !== readableBefore,
+            before: {
+                rawJson: rawBefore,
+                readableText: readableBefore,
+            },
+            after: {
+                rawJson: rawAfter,
+                readableText: readableAfter,
+            },
+        };
+    }
+
+    const readableAfter = `原文不可解析\n原文(raw): ${rawBefore}`;
+    return {
+        id,
+        parseStatus: 'invalid-json',
+        changed: readableAfter !== readableBefore,
+        before: {
+            rawJson: rawBefore,
+            readableText: readableBefore,
+        },
+        after: {
+            rawJson: rawBefore,
+            readableText: readableAfter,
+        },
+    };
+}
+
+// 0299_runMigration_run native lookup json migration
+function runMigration(options = {}) {
+    const db = options.db || new ProxyHubDb(config);
+    const startedAt = Date.now();
+
+    try {
+        const parsedArgs = parseArgs(options.argv || process.argv.slice(2));
+        const rows = parsedArgs.limit > 0
+            ? db.db.prepare(`
+                SELECT id, native_lookup_raw_json, native_lookup_readable_text
+                FROM proxies
+                WHERE TRIM(COALESCE(native_lookup_raw_json, '')) <> ''
+                ORDER BY id ASC
+                LIMIT ?
+            `).all(parsedArgs.limit)
+            : db.db.prepare(`
+                SELECT id, native_lookup_raw_json, native_lookup_readable_text
+                FROM proxies
+                WHERE TRIM(COALESCE(native_lookup_raw_json, '')) <> ''
+                ORDER BY id ASC
+            `).all();
+
+        const preparedRows = rows
+            .map((row) => buildMigrationRow(row))
+            .filter(Boolean);
+        const changedRows = preparedRows.filter((row) => row.changed);
+        const parsedCount = preparedRows.filter((row) => row.parseStatus === 'parsed').length;
+        const invalidCount = preparedRows.filter((row) => row.parseStatus === 'invalid-json').length;
+
+        if (!parsedArgs.dryRun && changedRows.length > 0) {
+            const nowIso = new Date().toISOString();
+            const updateStmt = db.db.prepare(`
+                UPDATE proxies
+                SET native_lookup_raw_json = @native_lookup_raw_json,
+                    native_lookup_readable_text = @native_lookup_readable_text,
+                    updated_at = @updated_at
+                WHERE id = @id
+            `);
+            const tx = db.db.transaction((items) => {
+                for (const item of items) {
+                    updateStmt.run({
+                        id: item.id,
+                        native_lookup_raw_json: item.after.rawJson,
+                        native_lookup_readable_text: item.after.readableText,
+                        updated_at: nowIso,
+                    });
+                }
+            });
+            tx(changedRows);
+        }
+
+        return {
+            ok: true,
+            result: {
+                dryRun: parsedArgs.dryRun,
+                limit: parsedArgs.limit,
+                total: rows.length,
+                prepared: preparedRows.length,
+                parsed: parsedCount,
+                invalid: invalidCount,
+                changed: changedRows.length,
+                updated: parsedArgs.dryRun ? 0 : changedRows.length,
+                sample: changedRows.slice(0, parsedArgs.sample).map((row) => ({
+                    id: row.id,
+                    parseStatus: row.parseStatus,
+                    before: row.before,
+                    after: row.after,
+                })),
+                durationMs: Date.now() - startedAt,
+            },
+        };
+    } catch (error) {
+        return {
+            ok: false,
+            error: error?.message || String(error),
+        };
+    } finally {
+        if (!options.db) {
+            db.close();
+        }
+    }
+}
+
+/* c8 ignore next 7 */
+if (require.main === module) {
+    const outcome = runMigration();
+    console.log(JSON.stringify(outcome, null, 2));
+    if (!outcome.ok) {
+        process.exit(1);
+    }
+}
+
+module.exports = {
+    parseArgs,
+    tryParseJson,
+    buildMigrationRow,
+    runMigration,
+};

--- a/apps/proxy-pool-service/src/migrate-native-lookup-json-format.test.js
+++ b/apps/proxy-pool-service/src/migrate-native-lookup-json-format.test.js
@@ -1,0 +1,253 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const config = require('./config');
+const { ProxyHubDb } = require('./db');
+const {
+    parseArgs,
+    tryParseJson,
+    buildMigrationRow,
+    runMigration,
+} = require('./migrate-native-lookup-json-format');
+
+// 0300_createDbHandle_create sqlite handle for migration tests
+function createDbHandle() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'proxyhub-native-json-migrate-'));
+    const dbPath = path.join(dir, 'proxyhub-native-json.db');
+    const db = new ProxyHubDb({
+        storage: {
+            dbPath,
+            snapshotRetentionDays: 7,
+        },
+    });
+    return { dir, dbPath, db };
+}
+
+// 0301_cleanup_cleanup sqlite handle for migration tests
+function cleanup(handle) {
+    handle.db.close();
+    fs.rmSync(handle.dir, { recursive: true, force: true });
+}
+
+test('parseArgs should parse apply/dry-run/sample/limit flags', () => {
+    assert.deepEqual(parseArgs([]), { dryRun: true, sample: 20, limit: 0 });
+    assert.deepEqual(parseArgs('bad-argv'), { dryRun: true, sample: 20, limit: 0 });
+    assert.deepEqual(parseArgs(['--apply']), { dryRun: false, sample: 20, limit: 0 });
+    assert.deepEqual(parseArgs(['--apply', '--sample', '8', '--limit', '99']), { dryRun: false, sample: 8, limit: 99 });
+    assert.deepEqual(parseArgs(['--sample', '999']), { dryRun: true, sample: 200, limit: 0 });
+    assert.throws(() => parseArgs(['--sample', '0']), /invalid-sample-value/);
+    assert.throws(() => parseArgs(['--limit', '-1']), /invalid-limit-value/);
+    assert.throws(() => parseArgs(['--unknown']), /unknown-arg/);
+});
+
+test('tryParseJson should cover parsed invalid and empty branches', () => {
+    assert.deepEqual(tryParseJson('{"a":1}'), {
+        ok: true,
+        reason: 'parsed',
+        value: { a: 1 },
+        text: '{"a":1}',
+    });
+    assert.deepEqual(tryParseJson('{bad-json'), {
+        ok: false,
+        reason: 'invalid-json',
+        value: undefined,
+        text: '{bad-json',
+    });
+    assert.deepEqual(tryParseJson('  '), {
+        ok: false,
+        reason: 'empty',
+        value: undefined,
+        text: '',
+    });
+    assert.deepEqual(tryParseJson(null), {
+        ok: false,
+        reason: 'empty',
+        value: undefined,
+        text: '',
+    });
+});
+
+test('buildMigrationRow should build parsed/invalid/empty row payloads', () => {
+    const parsedRow = buildMigrationRow({
+        id: 1,
+        native_lookup_raw_json: '{"z":2,"a":1}',
+        native_lookup_readable_text: '',
+    });
+    assert.equal(parsedRow.parseStatus, 'parsed');
+    assert.equal(parsedRow.changed, true);
+    assert.equal(parsedRow.after.rawJson, '{\n  "a": 1,\n  "z": 2\n}');
+    assert.equal(parsedRow.after.readableText.includes('原键名(a): 1'), true);
+
+    const invalidRow = buildMigrationRow({
+        id: 2,
+        native_lookup_raw_json: '{bad-json',
+        native_lookup_readable_text: '',
+    });
+    assert.equal(invalidRow.parseStatus, 'invalid-json');
+    assert.equal(invalidRow.after.rawJson, '{bad-json');
+    assert.equal(invalidRow.after.readableText.startsWith('原文不可解析'), true);
+
+    const emptyRow = buildMigrationRow({
+        id: 3,
+        native_lookup_raw_json: '   ',
+        native_lookup_readable_text: '',
+    });
+    assert.equal(emptyRow, null);
+
+    const nullishFieldsRow = buildMigrationRow({
+        id: 4,
+    });
+    assert.equal(nullishFieldsRow, null);
+
+    const unchangedRow = buildMigrationRow({
+        id: 5,
+        native_lookup_raw_json: '{\n  "a": 1\n}',
+        native_lookup_readable_text: '原键名(a): 1',
+    });
+    assert.equal(unchangedRow.parseStatus, 'parsed');
+    assert.equal(unchangedRow.changed, false);
+});
+
+test('runMigration should report and apply parsed/invalid native rows', () => {
+    const h = createDbHandle();
+    const now = new Date().toISOString();
+
+    h.db.upsertSourceBatch(
+        [
+            { ip: '99.0.0.1', port: 80, protocol: 'http' },
+            { ip: '99.0.0.2', port: 80, protocol: 'http' },
+            { ip: '99.0.0.3', port: 80, protocol: 'http' },
+        ],
+        (() => {
+            let i = 0;
+            return () => `籍贯迁移-${++i}`;
+        })(),
+        'src-native-migrate',
+        'batch-native-migrate',
+        now,
+    );
+    const rows = h.db.getProxyList({ limit: 10 });
+    h.db.updateProxyById(rows[0].id, {
+        native_lookup_raw_json: '{"z":2,"a":1}',
+        native_lookup_readable_text: '',
+        updated_at: now,
+    });
+    h.db.updateProxyById(rows[1].id, {
+        native_lookup_raw_json: '{bad-json',
+        native_lookup_readable_text: '',
+        updated_at: now,
+    });
+    h.db.updateProxyById(rows[2].id, {
+        native_lookup_raw_json: '',
+        native_lookup_readable_text: '',
+        updated_at: now,
+    });
+
+    const dryRun = runMigration({
+        db: h.db,
+        argv: ['--dry-run', '--sample', '5'],
+    });
+    assert.equal(dryRun.ok, true);
+    assert.equal(dryRun.result.total, 2);
+    assert.equal(dryRun.result.prepared, 2);
+    assert.equal(dryRun.result.parsed, 1);
+    assert.equal(dryRun.result.invalid, 1);
+    assert.equal(dryRun.result.changed, 2);
+    assert.equal(dryRun.result.updated, 0);
+
+    const beforeApply = h.db.getProxyById(rows[0].id);
+    assert.equal(beforeApply.native_lookup_raw_json, '{"z":2,"a":1}');
+
+    const apply = runMigration({
+        db: h.db,
+        argv: ['--apply', '--limit', '2'],
+    });
+    assert.equal(apply.ok, true);
+    assert.equal(apply.result.total, 2);
+    assert.equal(apply.result.updated, 2);
+
+    const parsedAfter = h.db.getProxyById(rows[0].id);
+    const invalidAfter = h.db.getProxyById(rows[1].id);
+    assert.equal(parsedAfter.native_lookup_raw_json, '{\n  "a": 1,\n  "z": 2\n}');
+    assert.equal(parsedAfter.native_lookup_readable_text.includes('原键名(a): 1'), true);
+    assert.equal(invalidAfter.native_lookup_raw_json, '{bad-json');
+    assert.equal(invalidAfter.native_lookup_readable_text.startsWith('原文不可解析'), true);
+
+    cleanup(h);
+});
+
+test('runMigration should return failure payload when args are invalid', () => {
+    const h = createDbHandle();
+    const failed = runMigration({
+        db: h.db,
+        argv: ['--sample', '0'],
+    });
+    assert.equal(failed.ok, false);
+    assert.equal(failed.error, 'invalid-sample-value');
+    cleanup(h);
+});
+
+test('runMigration should fallback error text when thrown value has no message', () => {
+    const fakeDb = {
+        db: {
+            prepare() {
+                throw null;
+            },
+        },
+    };
+    const result = runMigration({
+        db: fakeDb,
+        argv: ['--dry-run'],
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.error, 'null');
+});
+
+test('runMigration should close internally created db when db is not injected', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'proxyhub-native-json-run-'));
+    const dbPath = path.join(tempDir, 'proxyhub-native-json-run.db');
+    const previousDbPath = config.storage.dbPath;
+    config.storage.dbPath = dbPath;
+
+    try {
+        const result = runMigration({
+            argv: ['--dry-run', '--sample', '1'],
+        });
+        assert.equal(result.ok, true);
+        assert.equal(result.result.dryRun, true);
+        assert.equal(fs.existsSync(dbPath), true);
+    } finally {
+        config.storage.dbPath = previousDbPath;
+        try {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        } catch {
+            // ignore windows sqlite lock cleanup races
+        }
+    }
+});
+
+test('cli main should return non-zero and close db on failure', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'proxyhub-native-json-cli-'));
+    const dbPath = path.join(tempDir, 'proxyhub-native-json-cli.db');
+    const scriptPath = path.join(__dirname, 'migrate-native-lookup-json-format.js');
+    const proc = spawnSync(
+        process.execPath,
+        [scriptPath, '--sample', '0'],
+        {
+            cwd: path.resolve(__dirname, '..', '..', '..'),
+            env: {
+                ...process.env,
+                PROXY_HUB_DB_PATH: dbPath,
+            },
+            encoding: 'utf8',
+        },
+    );
+
+    assert.equal(proc.status, 1);
+    assert.match((proc.stderr || '') + (proc.stdout || ''), /invalid-sample-value/);
+    assert.equal(fs.existsSync(dbPath), true);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+});

--- a/apps/proxy-pool-service/src/server.test.js
+++ b/apps/proxy-pool-service/src/server.test.js
@@ -137,6 +137,7 @@ function createStubs() {
             service_branch: '陆军',
             native_place: '未知',
             native_lookup_raw_json: '',
+            native_lookup_readable_text: '',
             l0_success_count: 9,
             l0_fail_count: 1,
             l1_success_count: 4,
@@ -312,6 +313,7 @@ test('server runtime should expose all REST endpoints and shutdown cleanly', asy
     assert.equal(typeof valueBoardPayload.items[0].l3_fail_count, 'number');
     assert.equal(typeof valueBoardPayload.items[0].native_place, 'string');
     assert.equal(typeof valueBoardPayload.items[0].native_lookup_raw_json, 'string');
+    assert.equal(typeof valueBoardPayload.items[0].native_lookup_readable_text, 'string');
 
     const patchOk = await fetch(baseUrl + '/v1/proxies/policy', {
         method: 'POST',

--- a/apps/proxy-pool-service/src/views.test.js
+++ b/apps/proxy-pool-service/src/views.test.js
@@ -24,8 +24,13 @@ test('renderProxyAdminPage should inject refresh interval', () => {
     assert.equal(html.includes(" + ' [' + serviceBranch + ']'"), false);
     assert.equal(html.includes("esc(displayName) + '</td>'"), true);
     assert.equal(html.includes("esc(serviceBranch) + '</td>'"), true);
-    assert.equal(html.includes("const nativeTip = nativePlace === '未知'"), true);
-    assert.equal(html.includes("'<td title=\"' + esc(nativeTip) + '\">' + esc(nativePlace) + '</td>'"), true);
+    assert.equal(html.includes("function normalizeNativeTooltipText(value)"), true);
+    assert.equal(html.includes("const nativeReadable = normalizeNativeTooltipText(x.native_lookup_readable_text);"), true);
+    assert.equal(html.includes("const nativeRaw = normalizeNativeTooltipText(x.native_lookup_raw_json);"), true);
+    assert.equal(html.includes("class=\"native-tooltip\""), true);
+    assert.equal(html.includes("中文翻译"), true);
+    assert.equal(html.includes("原始JSON"), true);
+    assert.equal(html.includes("'<td class=\"native-cell\"><span class=\"native-place\">' + esc(nativePlace) + '</span>' + nativeTooltip + '</td>'"), true);
     assert.equal(html.includes("label: 'L0'"), true);
     assert.equal(html.includes("label: 'L1'"), true);
     assert.equal(html.includes("label: 'L2'"), true);

--- a/apps/proxy-pool-service/src/views/proxy-admin.html
+++ b/apps/proxy-pool-service/src/views/proxy-admin.html
@@ -41,6 +41,31 @@
     th, td { border-bottom: 1px solid var(--line); padding: 6px 4px; text-align: left; }
     th { color: var(--muted); font-weight: 600; }
     th[title] { cursor: help; text-decoration: underline dotted rgba(158, 177, 216, 0.7); text-underline-offset: 2px; }
+    .native-cell { position: relative; min-width: 110px; }
+    .native-place { border-bottom: 1px dotted rgba(158, 177, 216, 0.7); cursor: help; }
+    .native-tooltip {
+      display: none;
+      position: absolute;
+      top: calc(100% + 6px);
+      left: 0;
+      z-index: 60;
+      width: min(460px, 70vw);
+      max-height: 320px;
+      overflow: auto;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 10px;
+      background: linear-gradient(180deg, #111e36, #0b162b);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-family: Consolas, monospace;
+      font-size: 12px;
+      line-height: 1.4;
+    }
+    .native-cell:hover .native-tooltip { display: block; }
+    .native-tooltip-title { color: #c9d9f8; font-weight: 600; margin-bottom: 4px; }
+    .native-tooltip-section + .native-tooltip-section { margin-top: 8px; }
     .ok { color: var(--ok); }
     .warn { color: var(--warn); }
     .bad { color: var(--bad); }
@@ -96,6 +121,10 @@ function fmt(n) { return n == null ? '-' : n; }
 function esc(v) { return String(v == null ? '-' : v).replace(/[&<>"']/g, function(m){ return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]; }); }
 function fmtPercent(ratio) { return fmt(Number((Number(ratio || 0) * 100).toFixed(1))) + '%'; }
 function fmtScore(value) { return fmt(Number(value || 0).toFixed(2)); }
+function normalizeNativeTooltipText(value) {
+  const text = String(value == null ? '' : value).trim();
+  return text.length > 0 ? text : '未知';
+}
 function fmtSuccessTotalPercent(success, total) {
   const s = Number(success || 0);
   const t = Number(total || 0);
@@ -247,9 +276,13 @@ async function loadAll() {
     const displayName = x.display_name || '-';
     const serviceBranch = x.service_branch || '陆军';
     const nativePlace = x.native_place || '未知';
-    const nativeTip = nativePlace === '未知'
-      ? '未知'
-      : (x.native_lookup_raw_json || '未知');
+    const nativeReadable = normalizeNativeTooltipText(x.native_lookup_readable_text);
+    const nativeRaw = normalizeNativeTooltipText(x.native_lookup_raw_json);
+    const nativeTooltip = ''
+      + '<div class="native-tooltip">'
+      + '<div class="native-tooltip-section"><div class="native-tooltip-title">中文翻译</div><div>' + esc(nativeReadable) + '</div></div>'
+      + '<div class="native-tooltip-section"><div class="native-tooltip-title">原始JSON</div><div>' + esc(nativeRaw) + '</div></div>'
+      + '</div>';
     const l0Total = Number(x.l0_success_count || 0) + Number(x.l0_fail_count || 0);
     const l1Total = Number(x.l1_success_count || 0) + Number(x.l1_fail_count || 0);
     const l2Total = Number(x.l2_success_count || 0) + Number(x.l2_fail_count || 0);
@@ -260,7 +293,7 @@ async function loadAll() {
       + '<td>' + esc(displayName) + '</td>'
       + '<td>' + esc(serviceBranch) + '</td>'
       + '<td>' + esc(x.rank) + '</td>'
-      + '<td title="' + esc(nativeTip) + '">' + esc(nativePlace) + '</td>'
+      + '<td class="native-cell"><span class="native-place">' + esc(nativePlace) + '</span>' + nativeTooltip + '</td>'
       + '<td class="ok">' + fmtScore(x.ip_value_score) + '</td>'
       + '<td>' + esc(x.lifecycle) + '</td>'
       + '<td>' + fmtPercent(x.success_ratio) + '</td>'

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "watch:soak": "node apps/proxy-pool-service/src/soak-watchdog-v2.js",
     "migrate:proxyhub:names": "node apps/proxy-pool-service/src/migrate-display-names.js",
     "migrate:proxyhub:runtime-logs": "node apps/proxy-pool-service/src/migrate-runtime-log-localization.js",
+    "migrate:proxyhub:native-json": "node apps/proxy-pool-service/src/migrate-native-lookup-json-format.js",
     "test:proxyhub": "node --test apps/proxy-pool-service/src/**/*.test.js apps/proxy-pool-service/tests/**/*.integration.test.js",
     "test:proxyhub:unit": "node --test apps/proxy-pool-service/src/**/*.test.js",
     "test:proxyhub:integration": "node --test apps/proxy-pool-service/tests/**/*.integration.test.js",


### PR DESCRIPTION
﻿## 背景
对应 #90：籍贯原始 JSON 需要统一格式化并提升可读性。

## 改动
- 新增字段 `native_lookup_readable_text`（建表+自动补列），并透传到 list/value-board API。
- 籍贯解析成功后：
  - `native_lookup_raw_json` 统一为稳定键序 + pretty JSON。
  - `native_lookup_readable_text` 写入中文可读文本（全字段；未知键回退 `原键名(key)`）。
- 管理页籍贯列 hover 改为双段“吹出”：
  - 中文翻译
  - 原始JSON
- 新增迁移脚本 `migrate-native-lookup-json-format.js`：
  - 可解析 JSON：回填规范化 raw + readable
  - 不可解析 JSON：保留 raw，标记“原文不可解析”
- 新增 npm 脚本：`migrate:proxyhub:native-json`

## 测试
- 新增/更新单测覆盖：engine/db/server/views/migration。
- 覆盖率命令通过：
  - `npm run test:proxyhub:coverage`
  - 结果：`lines 100% / branches 98.12% / functions 100% / statements 100%`

## 验证
- 已执行迁移 dry-run/apply（目标库：`apps/proxy-pool-service/data/proxyhub-speedx-bundle.db`）
- 结果：93 条记录完成回填，`raw_json` 与 `readable_text` 均已落库。

Closes #90
