### PR TITLE
feat(proxy-hub): #106 add L4 branch flow and UI updates

### DIFF
--- a/apps/proxy-pool-service/src/config.js
+++ b/apps/proxy-pool-service/src/config.js
@@ -254,16 +254,19 @@ const battleL3SyncMsByProfile = {
 
 const defaultBattleL3Targets = [
     {
-        name: 'ly-flight-browser',
-        url: process.env.PROXY_HUB_BATTLE_L3_PRIMARY_URL
-            || process.env.PROXY_HUB_BATTLE_L2_PRIMARY_URL
-            || 'https://www.ly.com/flights/home',
-    },
-    {
         name: 'baidu-browser',
-        url: process.env.PROXY_HUB_BATTLE_L3_SECONDARY_URL
+        url: process.env.PROXY_HUB_BATTLE_L3_PRIMARY_URL
+            || process.env.PROXY_HUB_BATTLE_L3_SECONDARY_URL
             || process.env.PROXY_HUB_BATTLE_L2_FALLBACK_URL
             || 'https://www.baidu.com',
+    },
+];
+const defaultBattleL4Targets = [
+    {
+        name: 'ly-flight-browser',
+        url: process.env.PROXY_HUB_BATTLE_L4_PRIMARY_URL
+            || process.env.PROXY_HUB_BATTLE_L2_PRIMARY_URL
+            || 'https://www.ly.com/flights/home',
     },
 ];
 const resolvedBattleL3Targets = parseJsonArrayEnv(
@@ -274,6 +277,17 @@ const resolvedBattleL3Targets = parseJsonArrayEnv(
     url: String(target?.url || ''),
 })).filter((target) => target.url.length > 0);
 const resolvedBattleL3Protocols = String(process.env.PROXY_HUB_BATTLE_L3_ALLOWED_PROTOCOLS || 'http,https,socks5')
+    .split(',')
+    .map((protocol) => String(protocol || '').trim().toLowerCase())
+    .filter((protocol, index, list) => protocol.length > 0 && list.indexOf(protocol) === index);
+const resolvedBattleL4Targets = parseJsonArrayEnv(
+    process.env.PROXY_HUB_BATTLE_L4_TARGETS_JSON,
+    defaultBattleL4Targets,
+).map((target) => ({
+    name: String(target?.name || target?.url || 'l4-target'),
+    url: String(target?.url || ''),
+})).filter((target) => target.url.length > 0);
+const resolvedBattleL4Protocols = String(process.env.PROXY_HUB_BATTLE_L4_ALLOWED_PROTOCOLS || 'http,https,socks5')
     .split(',')
     .map((protocol) => String(protocol || '').trim().toLowerCase())
     .filter((protocol, index, list) => protocol.length > 0 && list.indexOf(protocol) === index);
@@ -316,9 +330,9 @@ const resolvedStateReviewLifecycleQuota = parseLifecycleQuota(
 
 const defaultBranchingRules = [
     {
-        id: 'l2_promote_navy',
+        id: 'l3_promote_navy',
         priority: 10,
-        stage: 'l2',
+        stage: 'l3',
         outcomes: ['success'],
         from: ['陆军'],
         to: '海军',
@@ -326,18 +340,18 @@ const defaultBranchingRules = [
         eventType: 'branch_transfer',
     },
     {
-        id: 'l2_reset_navy_streak',
+        id: 'l3_reset_navy_streak',
         priority: 20,
-        stage: 'l2',
+        stage: 'l3',
         outcomes: ['success'],
         from: ['海军'],
         failStreakOp: 'reset',
         eventType: 'branch_streak_reset',
     },
     {
-        id: 'l2_fail_navy_fallback',
+        id: 'l3_fail_navy_fallback',
         priority: 30,
-        stage: 'l2',
+        stage: 'l3',
         outcomes: ['blocked', 'timeout', 'network_error', 'invalid_feedback'],
         from: ['海军'],
         failStreakOp: 'increment',
@@ -346,9 +360,9 @@ const defaultBranchingRules = [
         eventType: 'branch_fallback',
     },
     {
-        id: 'l3_promote_seal',
+        id: 'l4_promote_seal',
         priority: 40,
-        stage: 'l3',
+        stage: 'l4',
         outcomes: ['success'],
         from: ['陆军', '海军', '海豹突击队'],
         to: '海豹突击队',
@@ -356,9 +370,9 @@ const defaultBranchingRules = [
         eventType: 'branch_transfer',
     },
     {
-        id: 'l3_fail_seal_fallback',
+        id: 'l4_fail_seal_fallback',
         priority: 50,
-        stage: 'l3',
+        stage: 'l4',
         outcomes: ['blocked', 'timeout', 'network_error', 'invalid_feedback'],
         from: ['海豹突击队'],
         failStreakOp: 'increment',
@@ -570,6 +584,12 @@ module.exports = {
             allowedProtocols: deepClone(resolvedBattleL3Protocols),
             targets: deepClone(resolvedBattleL3Targets),
             syncMsByProfile: deepClone(battleL3SyncMsByProfile),
+        },
+        l4: {
+            enabled: toBool(process.env.PROXY_HUB_BATTLE_L4_ENABLED, true),
+            timeoutMs: Number(process.env.PROXY_HUB_BATTLE_L4_TIMEOUT_MS || process.env.PROXY_HUB_BATTLE_L3_TIMEOUT_MS || 120_000),
+            allowedProtocols: deepClone(resolvedBattleL4Protocols),
+            targets: deepClone(resolvedBattleL4Targets),
         },
         blockedStatusCodes: [401, 403, 429, 503],
         blockSignals: [

--- a/apps/proxy-pool-service/src/config.test.js
+++ b/apps/proxy-pool-service/src/config.test.js
@@ -6,6 +6,7 @@ function loadConfigWithEnv(overrides = {}) {
         'PROXY_HUB_BATTLE_L2_PRIMARY_URL',
         'PROXY_HUB_BATTLE_L3_PRIMARY_URL',
         'PROXY_HUB_BATTLE_L3_SECONDARY_URL',
+        'PROXY_HUB_BATTLE_L4_PRIMARY_URL',
         'PROXY_HUB_BATTLE_L2_FALLBACK_URL',
         'PROXY_HUB_BATTLE_L3_ENABLED',
         'PROXY_HUB_BATTLE_L3_MS',
@@ -19,6 +20,10 @@ function loadConfigWithEnv(overrides = {}) {
         'PROXY_HUB_BATTLE_L3_REQUIRE_L2_SUCCESS',
         'PROXY_HUB_BATTLE_L3_IMMEDIATE_ON_L0_SUCCESS',
         'PROXY_HUB_BATTLE_L3_TIMER_ENABLED',
+        'PROXY_HUB_BATTLE_L4_ENABLED',
+        'PROXY_HUB_BATTLE_L4_TIMEOUT_MS',
+        'PROXY_HUB_BATTLE_L4_ALLOWED_PROTOCOLS',
+        'PROXY_HUB_BATTLE_L4_TARGETS_JSON',
         'PROXY_HUB_BATTLE_L2_MS',
         'PROXY_HUB_FEATURE_STAGE_WEIGHTING',
         'PROXY_HUB_FEATURE_LIFECYCLE_HYSTERESIS',
@@ -138,8 +143,13 @@ test('config should expose required default values', { concurrency: false }, () 
     assert.equal(config.battle.l3.concurrency, 3);
     assert.equal(config.battle.l3.timeoutMs, 120000);
     assert.deepEqual(config.battle.l3.allowedProtocols, ['http', 'https', 'socks5']);
-    assert.equal(config.battle.l3.targets.length >= 2, true);
-    assert.equal(config.battle.l3.targets[0].url, 'https://www.ly.com/flights/home');
+    assert.equal(config.battle.l3.targets.length >= 1, true);
+    assert.equal(config.battle.l3.targets[0].url, 'https://www.baidu.com');
+    assert.equal(config.battle.l4.enabled, true);
+    assert.equal(config.battle.l4.timeoutMs, 120000);
+    assert.deepEqual(config.battle.l4.allowedProtocols, ['http', 'https', 'socks5']);
+    assert.equal(config.battle.l4.targets.length >= 1, true);
+    assert.equal(config.battle.l4.targets[0].url, 'https://www.ly.com/flights/home');
     assert.equal(config.failureBackoff.enabled, true);
     assert.equal(config.failureBackoff.maxMs, 21600000);
     assert.equal(Array.isArray(config.battle.targets.l1), true);
@@ -261,9 +271,26 @@ test('config should normalize battle l3 target and protocol env fallbacks', { co
     assert.deepEqual(config.battle.l3.allowedProtocols, ['https', 'socks5']);
 });
 
-test('config should include default l3 secondary browser target', { concurrency: false }, () => {
+test('config should include default l3/l4 browser targets', { concurrency: false }, () => {
     const config = loadConfigWithEnv();
     assert.equal(config.battle.l3.targets.some((item) => item.name === 'baidu-browser' && item.url === 'https://www.baidu.com'), true);
+    assert.equal(config.battle.l4.targets.some((item) => item.name === 'ly-flight-browser' && item.url === 'https://www.ly.com/flights/home'), true);
+});
+
+test('config should support battle l4 env overrides', { concurrency: false }, () => {
+    const config = loadConfigWithEnv({
+        PROXY_HUB_BATTLE_L4_ENABLED: 'false',
+        PROXY_HUB_BATTLE_L4_TIMEOUT_MS: '66000',
+        PROXY_HUB_BATTLE_L4_ALLOWED_PROTOCOLS: 'https,socks5',
+        PROXY_HUB_BATTLE_L4_TARGETS_JSON: JSON.stringify([
+            { name: 'l4-one', url: 'https://example.com/l4-1' },
+        ]),
+    });
+    assert.equal(config.battle.l4.enabled, false);
+    assert.equal(config.battle.l4.timeoutMs, 66000);
+    assert.deepEqual(config.battle.l4.allowedProtocols, ['https', 'socks5']);
+    assert.equal(config.battle.l4.targets.length, 1);
+    assert.equal(config.battle.l4.targets[0].name, 'l4-one');
 });
 
 test('config should support source override for line-based lists', { concurrency: false }, () => {

--- a/apps/proxy-pool-service/src/db.js
+++ b/apps/proxy-pool-service/src/db.js
@@ -1299,7 +1299,9 @@ class ProxyHubDb {
                 COALESCE(stage_stats.l2_success_count, 0) AS l2_success_count,
                 COALESCE(stage_stats.l2_fail_count, 0) AS l2_fail_count,
                 COALESCE(stage_stats.l3_success_count, 0) AS l3_success_count,
-                COALESCE(stage_stats.l3_fail_count, 0) AS l3_fail_count
+                COALESCE(stage_stats.l3_fail_count, 0) AS l3_fail_count,
+                COALESCE(stage_stats.l4_success_count, 0) AS l4_success_count,
+                COALESCE(stage_stats.l4_fail_count, 0) AS l4_fail_count
             FROM proxies
             AS p
             LEFT JOIN (
@@ -1310,7 +1312,9 @@ class ProxyHubDb {
                     SUM(CASE WHEN stage = 'l2' AND outcome = 'success' THEN 1 ELSE 0 END) AS l2_success_count,
                     SUM(CASE WHEN stage = 'l2' AND outcome IN ('blocked', 'timeout', 'network_error', 'invalid_feedback') THEN 1 ELSE 0 END) AS l2_fail_count,
                     SUM(CASE WHEN stage = 'l3' AND outcome = 'success' THEN 1 ELSE 0 END) AS l3_success_count,
-                    SUM(CASE WHEN stage = 'l3' AND outcome IN ('blocked', 'timeout', 'network_error', 'invalid_feedback') THEN 1 ELSE 0 END) AS l3_fail_count
+                    SUM(CASE WHEN stage = 'l3' AND outcome IN ('blocked', 'timeout', 'network_error', 'invalid_feedback') THEN 1 ELSE 0 END) AS l3_fail_count,
+                    SUM(CASE WHEN stage = 'l4' AND outcome = 'success' THEN 1 ELSE 0 END) AS l4_success_count,
+                    SUM(CASE WHEN stage = 'l4' AND outcome IN ('blocked', 'timeout', 'network_error', 'invalid_feedback') THEN 1 ELSE 0 END) AS l4_fail_count
                 FROM battle_test_runs
                 GROUP BY proxy_id
             ) AS stage_stats

--- a/apps/proxy-pool-service/src/db.test.js
+++ b/apps/proxy-pool-service/src/db.test.js
@@ -702,6 +702,17 @@ test('value board API should sort by value and parse breakdown and honor fields'
         reason: 'err',
         details: {},
     });
+    h.db.insertBattleTestRun({
+        timestamp: now,
+        proxy_id: all[0].id,
+        stage: 'l4',
+        target: 'l4-a',
+        outcome: 'success',
+        status_code: 200,
+        latency_ms: 55,
+        reason: 'ok',
+        details: {},
+    });
 
     const board = h.db.getValueBoard(10);
     assert.equal(board.length, 2);
@@ -719,6 +730,8 @@ test('value board API should sort by value and parse breakdown and honor fields'
     assert.equal(board[0].l2_fail_count, 1);
     assert.equal(board[0].l3_success_count, 0);
     assert.equal(board[0].l3_fail_count, 1);
+    assert.equal(board[0].l4_success_count, 1);
+    assert.equal(board[0].l4_fail_count, 0);
     assert.equal(board[0].native_place, '未知');
     assert.equal(board[0].native_lookup_status, 'pending');
     assert.equal(board[1].l0_success_count, 0);
@@ -729,6 +742,8 @@ test('value board API should sort by value and parse breakdown and honor fields'
     assert.equal(board[1].l2_fail_count, 0);
     assert.equal(board[1].l3_success_count, 0);
     assert.equal(board[1].l3_fail_count, 0);
+    assert.equal(board[1].l4_success_count, 0);
+    assert.equal(board[1].l4_fail_count, 0);
     assert.equal(board[1].native_place, '中国-北京');
     assert.equal(board[1].native_lookup_status, 'resolved');
     assert.equal(board[1].native_lookup_raw_json.includes('"country":"中国"'), true);

--- a/apps/proxy-pool-service/src/engine.js
+++ b/apps/proxy-pool-service/src/engine.js
@@ -244,9 +244,9 @@ function resolveSourceFeeds(config = {}) {
 const DEFAULT_BRANCH_FAIL_OUTCOMES = ['blocked', 'timeout', 'network_error', 'invalid_feedback'];
 const DEFAULT_BRANCHING_RULES = [
     {
-        id: 'l2_promote_navy',
+        id: 'l3_promote_navy',
         priority: 10,
-        stage: 'l2',
+        stage: 'l3',
         outcomes: ['success'],
         from: ['陆军'],
         to: '海军',
@@ -254,18 +254,18 @@ const DEFAULT_BRANCHING_RULES = [
         eventType: 'branch_transfer',
     },
     {
-        id: 'l2_reset_navy_streak',
+        id: 'l3_reset_navy_streak',
         priority: 20,
-        stage: 'l2',
+        stage: 'l3',
         outcomes: ['success'],
         from: ['海军'],
         failStreakOp: 'reset',
         eventType: 'branch_streak_reset',
     },
     {
-        id: 'l2_fail_navy_fallback',
+        id: 'l3_fail_navy_fallback',
         priority: 30,
-        stage: 'l2',
+        stage: 'l3',
         outcomes: DEFAULT_BRANCH_FAIL_OUTCOMES,
         from: ['海军'],
         failStreakOp: 'increment',
@@ -274,9 +274,9 @@ const DEFAULT_BRANCHING_RULES = [
         eventType: 'branch_fallback',
     },
     {
-        id: 'l3_promote_seal',
+        id: 'l4_promote_seal',
         priority: 40,
-        stage: 'l3',
+        stage: 'l4',
         outcomes: ['success'],
         from: ['陆军', '海军', '海豹突击队'],
         to: '海豹突击队',
@@ -284,9 +284,9 @@ const DEFAULT_BRANCHING_RULES = [
         eventType: 'branch_transfer',
     },
     {
-        id: 'l3_fail_seal_fallback',
+        id: 'l4_fail_seal_fallback',
         priority: 50,
-        stage: 'l3',
+        stage: 'l4',
         outcomes: DEFAULT_BRANCH_FAIL_OUTCOMES,
         from: ['海豹突击队'],
         failStreakOp: 'increment',
@@ -700,6 +700,11 @@ class ProxyHubEngine extends EventEmitter {
     // 0304_isBattleL3ImmediateOnL0Success_判断L0成功后立即执行L3开关逻辑
     isBattleL3ImmediateOnL0Success() {
         return this.isBattleL3Enabled() && this.config?.battle?.l3?.immediateOnL0Success === true;
+    }
+
+    // 0313_isBattleL4Enabled_判断战场L4开关逻辑
+    isBattleL4Enabled() {
+        return this.isBattleEnabled() && this.config?.battle?.l4?.enabled === true;
     }
 
     // 0298_setSourceCycleThrottleFactor_设置抓源节流倍率逻辑
@@ -1640,6 +1645,60 @@ class ProxyHubEngine extends EventEmitter {
         });
     }
 
+    // 0315_applyBranchingOutcomeOnly_仅应用编制流转逻辑
+    async applyBranchingOutcomeOnly({
+        proxyId,
+        sourceName,
+        outcome,
+        nowIso,
+        stage = '编制',
+        branchingStage = 'l4',
+    }) {
+        const currentProxy = this.db.getProxyById(proxyId);
+        if (!currentProxy) {
+            return { ok: false, reason: 'proxy-missing' };
+        }
+
+        const branchTransition = resolveBranchingTransition({
+            proxy: currentProxy,
+            stage: branchingStage,
+            outcome,
+            config: this.config,
+        });
+        if (Object.keys(branchTransition.updates).length > 0) {
+            this.db.updateProxyById(proxyId, {
+                ...branchTransition.updates,
+                updated_at: nowIso,
+            });
+        }
+        const updatedProxy = this.db.getProxyById(proxyId) || currentProxy;
+
+        for (const event of branchTransition.events) {
+            this.db.insertProxyEvent({
+                timestamp: nowIso,
+                proxy_id: proxyId,
+                display_name: updatedProxy.display_name,
+                event_type: event.event_type,
+                level: EVENT_LEVEL.INFO,
+                message: event.message,
+                details: event.details,
+            });
+            this.logger.write({
+                event: '编制流转',
+                proxyName: updatedProxy.display_name,
+                ipSource: sourceName,
+                stage: '编制',
+                result: event.message,
+                reason: `${event.details.branchBefore} -> ${event.details.branchAfter}`,
+                action: '按规则自动调整',
+                details: event.details,
+            });
+        }
+
+        this.scheduleNativeLookup(updatedProxy, sourceName, nowIso);
+        return { ok: true, applied: branchTransition.events.length > 0 };
+    }
+
     // 0033_processProxy_处理代理逻辑
     async processProxy(proxy, sourceName) {
         const cycleStart = Date.now();
@@ -2009,6 +2068,9 @@ class ProxyHubEngine extends EventEmitter {
                 branchingStage: 'l3',
                 extraUpdates: battleUpdates,
             });
+            if (result.outcome === 'success' && this.isBattleL4Enabled()) {
+                await this.runBattleL4TaskForProxy(proxy, 'battle-l4-browser', this.config?.battle?.l4 || {});
+            }
             return { ok: true, outcome: result.outcome };
         } catch (error) {
             const latest = this.db.getProxyById(proxy.id) || proxy;
@@ -2035,6 +2097,62 @@ class ProxyHubEngine extends EventEmitter {
                 action: '已触发失败退避',
             });
             return { ok: false, reason: error?.message || 'battle-l3-task-error' };
+        }
+    }
+
+    // 0314_runBattleL4TaskForProxy_执行单代理L4测试逻辑（仅记录，不计分）
+    async runBattleL4TaskForProxy(proxy, sourceName = 'battle-l4-browser', l4Config = this.config?.battle?.l4 || {}) {
+        if (!this.isBattleL4Enabled()) {
+            return { ok: false, reason: 'battle-l4-disabled' };
+        }
+        const nowIso = this.now().toISOString();
+        try {
+            const result = await this.workerPool.runTask('battle-l4-browser', {
+                proxy: {
+                    ip: proxy.ip,
+                    port: proxy.port,
+                    protocol: proxy.protocol,
+                },
+                targets: l4Config.targets,
+                timeoutMs: l4Config.timeoutMs,
+                blockedStatusCodes: this.config.battle.blockedStatusCodes,
+                blockSignals: this.config.battle.blockSignals,
+                allowedProtocols: l4Config.allowedProtocols,
+            });
+
+            for (const run of result.runs || []) {
+                this.db.insertBattleTestRun({
+                    timestamp: nowIso,
+                    proxy_id: proxy.id,
+                    stage: 'l4',
+                    target: run.target,
+                    outcome: run.outcome,
+                    status_code: run.statusCode,
+                    latency_ms: run.latencyMs,
+                    reason: run.reason,
+                    details: run.details,
+                });
+            }
+            await this.applyBranchingOutcomeOnly({
+                proxyId: proxy.id,
+                sourceName,
+                outcome: result.outcome,
+                nowIso,
+                stage: '编制(L4)',
+                branchingStage: 'l4',
+            });
+            return { ok: true, outcome: result.outcome };
+        } catch (error) {
+            this.logger.write({
+                event: '战场测试L4失败',
+                proxyName: proxy.display_name,
+                ipSource: sourceName,
+                stage: '战场测试L4',
+                result: '异常',
+                reason: error?.message || 'battle-l4-task-error',
+                action: '仅记录，不计分',
+            });
+            return { ok: false, reason: error?.message || 'battle-l4-task-error' };
         }
     }
 

--- a/apps/proxy-pool-service/src/engine.test.js
+++ b/apps/proxy-pool-service/src/engine.test.js
@@ -55,6 +55,12 @@ function createConfig(dbPath) {
                 lookbackMinutes: 10,
                 timeoutMs: 12000,
                 allowedProtocols: ['http', 'https', 'socks5'],
+                targets: [{ name: 'baidu-browser', url: 'https://www.baidu.com' }],
+            },
+            l4: {
+                enabled: true,
+                timeoutMs: 12000,
+                allowedProtocols: ['http', 'https', 'socks5'],
                 targets: [{ name: 'ly-browser', url: 'https://www.ly.com/flights/home' }],
             },
             blockedStatusCodes: [401, 403, 429, 503],
@@ -423,7 +429,7 @@ test('engine utility functions should cover helper branches', async () => {
     assert.deepEqual(stringRulePolicy.rules[0].from, ['*']);
     const branchPromote = resolveBranchingTransition({
         proxy: { service_branch: '陆军', branch_fail_streak: 0 },
-        stage: 'l2',
+        stage: 'l3',
         outcome: 'success',
         config: {},
     });
@@ -483,7 +489,7 @@ test('engine utility functions should cover helper branches', async () => {
     assert.deepEqual(branchNoop, { updates: {}, events: [] });
     const branchResetOnly = resolveBranchingTransition({
         proxy: { service_branch: '海军', branch_fail_streak: 2 },
-        stage: 'l2',
+        stage: 'l3',
         outcome: 'success',
         config: {},
     });
@@ -1820,7 +1826,7 @@ test('processProxy success should fallback latency to zero when missing', async 
     cleanupDb(h);
 });
 
-test('processProxy should trigger L3 immediately after L0 success when enabled', async () => {
+test('processProxy should trigger L3 immediately after L0 success and chain L4 on L3 success', async () => {
     const h = createDbHandle();
     const logger = createLogger();
     h.config.battle.enabled = true;
@@ -1853,6 +1859,14 @@ test('processProxy should trigger L3 immediately after L0 success when enabled',
                     runs: [{ target: 'ly-browser', outcome: 'success', statusCode: 200, latencyMs: 35, reason: 'ok', details: {} }],
                 };
             }
+            if (type === 'battle-l4-browser') {
+                return {
+                    stage: 'l4',
+                    outcome: 'success',
+                    latencyMs: 40,
+                    runs: [{ target: 'ly-browser', outcome: 'success', statusCode: 200, latencyMs: 40, reason: 'ok', details: {} }],
+                };
+            }
             return { ok: true };
         },
         getStatus() {
@@ -1866,9 +1880,398 @@ test('processProxy should trigger L3 immediately after L0 success when enabled',
     const runs = h.db.getBattleTestRuns(10);
     assert.equal(callTypes.includes('validate-proxy'), true);
     assert.equal(callTypes.includes('battle-l3-browser'), true);
+    assert.equal(callTypes.includes('battle-l4-browser'), true);
     assert.equal(runs.some((run) => run.stage === 'l3'), true);
+    assert.equal(runs.some((run) => run.stage === 'l4'), true);
     assert.equal(logger.entries.some((e) => e.action === 'L0成功后立即执行L3'), true);
     assert.equal(logger.entries.some((e) => e.stage === '评分(L0回退)'), false);
+
+    cleanupDb(h);
+});
+
+test('engine start should log battle disabled action when no battle stage is active', async () => {
+    const h = createDbHandle();
+    const logger = createLogger();
+    h.config.battle.enabled = true;
+    h.config.battle.l3Only = true;
+    h.config.battle.l3.enabled = false;
+    h.config.battle.l3.immediateOnL0Success = false;
+    h.config.battle.l3.timerEnabled = false;
+
+    const workerPool = {
+        async runTask() {
+            return { ok: true };
+        },
+        getStatus() {
+            return { workersTotal: 2, workersBusy: 0, queueSize: 0, runningTasks: 0, completedTasks: 0, failedTasks: 0, restartedWorkers: 0, workers: [] };
+        },
+    };
+    const engine = new ProxyHubEngine({ config: h.config, db: h.db, workerPool, logger, now: () => new Date('2026-03-14T06:30:00.000Z') });
+
+    await engine.start();
+    assert.equal(logger.entries.some((item) => String(item.action || '').includes('战场测试已禁用')), true);
+
+    await engine.stop();
+    cleanupDb(h);
+});
+
+test('runBattleL3TaskForProxy should skip L4 chain when L3 result is not success', async () => {
+    const h = createDbHandle();
+    const logger = createLogger();
+    h.config.battle.enabled = true;
+    h.config.battle.l3.enabled = true;
+    h.config.battle.l4.enabled = true;
+    h.config.battle.l3.immediateOnL0Success = true;
+    h.db.upsertSourceBatch(
+        [{ ip: '10.0.0.88', port: 8080, protocol: 'http' }],
+        () => '苍隼-L3失败-88',
+        'src',
+        'batch',
+        new Date('2026-03-14T07:42:00.000Z').toISOString(),
+    );
+    const proxy = h.db.getProxyList({ limit: 1 })[0];
+    const callTypes = [];
+    const workerPool = {
+        async runTask(type) {
+            callTypes.push(type);
+            if (type === 'battle-l3-browser') {
+                return {
+                    stage: 'l3',
+                    outcome: 'timeout',
+                    latencyMs: 50,
+                    runs: [{ target: 'baidu-browser', outcome: 'timeout', statusCode: null, latencyMs: 50, reason: 'timeout', details: {} }],
+                };
+            }
+            return { ok: true };
+        },
+        getStatus() {
+            return { workersTotal: 2, workersBusy: 0, queueSize: 0, runningTasks: 0, completedTasks: 0, failedTasks: 0, restartedWorkers: 0, workers: [] };
+        },
+    };
+    const engine = new ProxyHubEngine({ config: h.config, db: h.db, workerPool, logger, now: () => new Date('2026-03-14T07:43:00.000Z') });
+    engine.applyCombatOutcome = async () => {};
+    await engine.runBattleL3TaskForProxy(proxy, 'battle-l3-browser', h.config.battle.l3);
+    assert.equal(callTypes.includes('battle-l3-browser'), true);
+    assert.equal(callTypes.includes('battle-l4-browser'), false);
+    cleanupDb(h);
+});
+
+test('runBattleL3TaskForProxy should not chain L4 when L4 is disabled even if L3 succeeds', async () => {
+    const h = createDbHandle();
+    const logger = createLogger();
+    h.config.battle.enabled = true;
+    h.config.battle.l3.enabled = true;
+    h.config.battle.l4.enabled = false;
+    h.db.upsertSourceBatch(
+        [{ ip: '10.0.0.188', port: 8080, protocol: 'http' }],
+        () => '苍隼-L3成功-禁L4-188',
+        'src',
+        'batch',
+        new Date('2026-03-14T07:43:30.000Z').toISOString(),
+    );
+    const proxy = h.db.getProxyList({ limit: 1 })[0];
+    const callTypes = [];
+    const workerPool = {
+        async runTask(type) {
+            callTypes.push(type);
+            if (type === 'battle-l3-browser') {
+                return {
+                    stage: 'l3',
+                    outcome: 'success',
+                    latencyMs: 46,
+                    runs: [{ target: 'baidu-browser', outcome: 'success', statusCode: 200, latencyMs: 46, reason: 'ok', details: {} }],
+                };
+            }
+            return { ok: true };
+        },
+        getStatus() {
+            return { workersTotal: 2, workersBusy: 0, queueSize: 0, runningTasks: 0, completedTasks: 0, failedTasks: 0, restartedWorkers: 0, workers: [] };
+        },
+    };
+    const engine = new ProxyHubEngine({ config: h.config, db: h.db, workerPool, logger, now: () => new Date('2026-03-14T07:43:40.000Z') });
+    engine.applyCombatOutcome = async () => {};
+    await engine.runBattleL3TaskForProxy(proxy);
+    assert.equal(callTypes.includes('battle-l3-browser'), true);
+    assert.equal(callTypes.includes('battle-l4-browser'), false);
+    cleanupDb(h);
+});
+
+test('runBattleL4TaskForProxy should persist l4 runs and apply branch transitions without scoring', async () => {
+    const h = createDbHandle();
+    const logger = createLogger();
+    h.config.battle.enabled = true;
+    h.config.battle.l4.enabled = true;
+    h.db.upsertSourceBatch(
+        [{ ip: '10.0.0.89', port: 8080, protocol: 'http' }],
+        () => '苍隼-L4-89',
+        'src',
+        'batch',
+        new Date('2026-03-14T07:44:00.000Z').toISOString(),
+    );
+    const proxy = h.db.getProxyList({ limit: 1 })[0];
+
+    let mode = 'success';
+    let applyCalls = 0;
+    const workerPool = {
+        async runTask(type) {
+            if (type !== 'battle-l4-browser') {
+                return { ok: true };
+            }
+            if (mode === 'throw') {
+                throw new Error('battle-l4-boom');
+            }
+            if (mode === 'throw-null') {
+                throw null;
+            }
+            if (mode === 'network_error') {
+                return {
+                    stage: 'l4',
+                    outcome: 'network_error',
+                    latencyMs: 32,
+                    runs: [{ target: 'ly-browser', outcome: 'network_error', statusCode: null, latencyMs: 32, reason: 'ECONNRESET', details: {} }],
+                };
+            }
+            return {
+                stage: 'l4',
+                outcome: 'success',
+                latencyMs: 32,
+                runs: [{ target: 'ly-browser', outcome: 'success', statusCode: 200, latencyMs: 32, reason: 'browser_ok', details: {} }],
+            };
+        },
+        getStatus() {
+            return { workersTotal: 2, workersBusy: 0, queueSize: 0, runningTasks: 0, completedTasks: 0, failedTasks: 0, restartedWorkers: 0, workers: [] };
+        },
+    };
+    const engine = new ProxyHubEngine({ config: h.config, db: h.db, workerPool, logger, now: () => new Date('2026-03-14T07:45:00.000Z') });
+    engine.applyCombatOutcome = async () => {
+        applyCalls += 1;
+    };
+
+    const successResult = await engine.runBattleL4TaskForProxy(proxy, 'battle-l4-browser', h.config.battle.l4);
+    assert.equal(successResult.ok, true);
+    assert.equal(h.db.getBattleTestRuns(10).some((run) => run.stage === 'l4'), true);
+    assert.equal(h.db.getProxyById(proxy.id).service_branch, '海豹突击队');
+    assert.equal(h.db.getEvents(20).some((item) => item.event_type === 'branch_transfer'), true);
+    assert.equal(applyCalls, 0);
+
+    mode = 'network_error';
+    await engine.runBattleL4TaskForProxy(proxy, 'battle-l4-browser', h.config.battle.l4);
+    await engine.runBattleL4TaskForProxy(proxy, 'battle-l4-browser', h.config.battle.l4);
+    await engine.runBattleL4TaskForProxy(proxy, 'battle-l4-browser', h.config.battle.l4);
+    const fallenBack = h.db.getProxyById(proxy.id);
+    assert.equal(fallenBack.service_branch, '陆军');
+    assert.equal(fallenBack.branch_fail_streak, 0);
+    assert.equal(h.db.getEvents(50).some((item) => item.event_type === 'branch_fallback'), true);
+
+    h.config.battle.l4.enabled = false;
+    const disabledResult = await engine.runBattleL4TaskForProxy(proxy, 'battle-l4-browser', h.config.battle.l4);
+    assert.equal(disabledResult.ok, false);
+    assert.equal(disabledResult.reason, 'battle-l4-disabled');
+
+    h.config.battle.l4.enabled = true;
+    mode = 'throw';
+    const failedResult = await engine.runBattleL4TaskForProxy(proxy, 'battle-l4-browser', h.config.battle.l4);
+    assert.equal(failedResult.ok, false);
+    assert.equal(logger.entries.some((entry) => entry.event === '战场测试L4失败' && entry.stage === '战场测试L4' && entry.reason === 'battle-l4-boom'), true);
+
+    mode = 'throw-null';
+    const failedNullReason = await engine.runBattleL4TaskForProxy(proxy, 'battle-l4-browser', h.config.battle.l4);
+    assert.equal(failedNullReason.ok, false);
+    assert.equal(failedNullReason.reason, 'battle-l4-task-error');
+
+    cleanupDb(h);
+});
+
+test('applyBranchingOutcomeOnly should handle missing proxy and no-op transitions', async () => {
+    const h = createDbHandle();
+    const logger = createLogger();
+    const workerPool = {
+        async runTask() {
+            return { ok: true };
+        },
+        getStatus() {
+            return { workersTotal: 1, workersBusy: 0, queueSize: 0, runningTasks: 0, completedTasks: 0, failedTasks: 0, restartedWorkers: 0, workers: [] };
+        },
+    };
+    const engine = new ProxyHubEngine({ config: h.config, db: h.db, workerPool, logger, now: () => new Date('2026-03-14T08:00:00.000Z') });
+
+    const missing = await engine.applyBranchingOutcomeOnly({
+        proxyId: 999,
+        sourceName: 'battle-l4-browser',
+        outcome: 'network_error',
+        nowIso: '2026-03-14T08:00:00.000Z',
+    });
+    assert.deepEqual(missing, { ok: false, reason: 'proxy-missing' });
+
+    h.db.upsertSourceBatch(
+        [{ ip: '10.0.0.90', port: 8080, protocol: 'http' }],
+        () => '苍隼-L4-Noop-90',
+        'src',
+        'batch',
+        '2026-03-14T08:00:00.000Z',
+    );
+    const proxy = h.db.getProxyList({ limit: 1 })[0];
+    const noOp = await engine.applyBranchingOutcomeOnly({
+        proxyId: proxy.id,
+        sourceName: 'battle-l4-browser',
+        outcome: 'network_error',
+        nowIso: '2026-03-14T08:00:00.000Z',
+        stage: '编制(L4)',
+        branchingStage: 'l4',
+    });
+    assert.equal(noOp.ok, true);
+    assert.equal(noOp.applied, false);
+    assert.equal(h.db.getEvents(20).some((item) => item.event_type === 'branch_transfer' || item.event_type === 'branch_fallback'), false);
+
+    h.db.updateProxyById(proxy.id, {
+        service_branch: '海军',
+        branch_fail_streak: 0,
+        updated_at: '2026-03-14T08:00:00.000Z',
+    });
+    const originalGetProxyById = h.db.getProxyById.bind(h.db);
+    let getCount = 0;
+    h.db.getProxyById = (id) => {
+        getCount += 1;
+        if (getCount === 1) {
+            return originalGetProxyById(id);
+        }
+        return null;
+    };
+    const fallbackToCurrentProxy = await engine.applyBranchingOutcomeOnly({
+        proxyId: proxy.id,
+        sourceName: 'battle-l4-browser',
+        outcome: 'success',
+        nowIso: '2026-03-14T08:00:01.000Z',
+        stage: '编制(L4)',
+        branchingStage: 'l4',
+    });
+    h.db.getProxyById = originalGetProxyById;
+    assert.equal(fallbackToCurrentProxy.ok, true);
+    assert.equal(fallbackToCurrentProxy.applied, true);
+    assert.equal(logger.entries.some((item) => item.event === '编制流转' && item.proxyName === proxy.display_name), true);
+
+    cleanupDb(h);
+});
+
+test('processProxy should fallback to input proxy when latest row is missing before immediate L3', async () => {
+    const h = createDbHandle();
+    const logger = createLogger();
+    h.config.battle.enabled = true;
+    h.config.battle.l3.enabled = true;
+    h.config.battle.l3.immediateOnL0Success = true;
+    h.config.battle.l3.requireRecentL2Success = false;
+
+    const now = new Date('2026-03-14T08:05:00.000Z').toISOString();
+    h.db.upsertSourceBatch(
+        [{ ip: '10.0.0.191', port: 8082, protocol: 'http' }],
+        () => '苍隼-L0兜底L3-191',
+        'src',
+        'batch',
+        now,
+    );
+    const proxy = h.db.getProxyList({ limit: 1 })[0];
+
+    const callTypes = [];
+    const workerPool = {
+        async runTask(type) {
+            callTypes.push(type);
+            if (type === 'validate-proxy') {
+                return { ok: true, reason: 'connect_ok', latencyMs: 8 };
+            }
+            if (type === 'battle-l3-browser') {
+                return {
+                    stage: 'l3',
+                    outcome: 'timeout',
+                    latencyMs: 60,
+                    runs: [{ target: 'baidu-browser', outcome: 'timeout', statusCode: null, latencyMs: 60, reason: 'timeout', details: {} }],
+                };
+            }
+            return { ok: true };
+        },
+        getStatus() {
+            return { workersTotal: 2, workersBusy: 0, queueSize: 0, runningTasks: 0, completedTasks: 0, failedTasks: 0, restartedWorkers: 0, workers: [] };
+        },
+    };
+
+    const engine = new ProxyHubEngine({ config: h.config, db: h.db, workerPool, logger, now: () => new Date('2026-03-14T08:05:10.000Z') });
+    const originalGetProxyById = h.db.getProxyById.bind(h.db);
+    h.db.getProxyById = () => null;
+    await engine.processProxy(proxy, 'src');
+    h.db.getProxyById = originalGetProxyById;
+
+    assert.equal(callTypes.includes('validate-proxy'), true);
+    assert.equal(callTypes.includes('battle-l3-browser'), true);
+    assert.equal(logger.entries.some((entry) => entry.action === 'L0成功后立即执行L3'), true);
+    cleanupDb(h);
+});
+
+test('processProxy and battle tasks should cover default empty battle config branches', async () => {
+    const h = createDbHandle();
+    const logger = createLogger();
+    h.config.battle.enabled = true;
+    h.config.battle.l3 = null;
+    h.config.battle.l4 = null;
+
+    const now = new Date('2026-03-14T08:06:00.000Z').toISOString();
+    h.db.upsertSourceBatch(
+        [{ ip: '10.0.0.192', port: 8082, protocol: 'http' }],
+        () => '苍隼-空配置-192',
+        'src',
+        'batch',
+        now,
+    );
+    const proxy = h.db.getProxyList({ limit: 1 })[0];
+
+    const taskCalls = [];
+    const workerPool = {
+        async runTask(type, payload) {
+            taskCalls.push({ type, payload });
+            if (type === 'validate-proxy') {
+                return { ok: true, reason: 'connect_ok', latencyMs: 7 };
+            }
+            if (type === 'battle-l3-browser') {
+                return {
+                    stage: 'l3',
+                    outcome: 'success',
+                    latencyMs: 33,
+                    runs: [{ target: 'baidu-browser', outcome: 'success', statusCode: 200, latencyMs: 33, reason: 'ok', details: {} }],
+                };
+            }
+            if (type === 'battle-l4-browser') {
+                return {
+                    stage: 'l4',
+                    outcome: 'success',
+                    latencyMs: 30,
+                    runs: [{ target: 'ly-browser', outcome: 'success', statusCode: 200, latencyMs: 30, reason: 'ok', details: {} }],
+                };
+            }
+            return { ok: true };
+        },
+        getStatus() {
+            return { workersTotal: 2, workersBusy: 0, queueSize: 0, runningTasks: 0, completedTasks: 0, failedTasks: 0, restartedWorkers: 0, workers: [] };
+        },
+    };
+
+    const engine = new ProxyHubEngine({ config: h.config, db: h.db, workerPool, logger, now: () => new Date('2026-03-14T08:06:10.000Z') });
+    engine.isBattleL3ImmediateOnL0Success = () => true;
+    engine.isBattleL4Enabled = () => true;
+    engine.applyCombatOutcome = async () => {};
+
+    await engine.processProxy(proxy, 'src');
+    const l3Task = taskCalls.find((item) => item.type === 'battle-l3-browser');
+    assert.equal(Boolean(l3Task), true);
+    assert.equal(l3Task.payload.targets, undefined);
+    assert.equal(l3Task.payload.timeoutMs, undefined);
+
+    await engine.runBattleL3TaskForProxy(proxy);
+    const l3Calls = taskCalls.filter((item) => item.type === 'battle-l3-browser');
+    assert.equal(l3Calls.length >= 2, true);
+
+    await engine.runBattleL4TaskForProxy(proxy);
+    const l4Task = taskCalls.find((item) => item.type === 'battle-l4-browser');
+    assert.equal(Boolean(l4Task), true);
+    assert.equal(l4Task.payload.targets, undefined);
+    assert.equal(l4Task.payload.timeoutMs, undefined);
 
     cleanupDb(h);
 });
@@ -1985,12 +2388,13 @@ test('applyCombatOutcome should resolve native place asynchronously for target b
 
     await engine.applyCombatOutcome({
         proxyId: proxy.id,
-        sourceName: 'battle-l2',
+        sourceName: 'battle-l3-browser',
         outcome: 'success',
         latencyMs: 18,
         nowIso,
-        stage: '评分(L2)',
+        stage: '评分(L3)',
         combatStage: 'l2',
+        branchingStage: 'l3',
     });
 
     const resolved = await waitFor(() => h.db.getProxyById(proxy.id)?.native_lookup_status === 'resolved');
@@ -2825,7 +3229,7 @@ test('resolveBranchingTransition should support custom rule extension', () => {
     assert.equal(transition.events[0].event_type, 'branch_transition');
 });
 
-test('applyCombatOutcome should apply l2 branch transfer and fallback rules', async () => {
+test('applyCombatOutcome should apply l3 branch transfer and fallback rules', async () => {
     const h = createDbHandle();
     const logger = createLogger();
     const now = '2026-03-14T10:00:00.000Z';
@@ -2850,12 +3254,13 @@ test('applyCombatOutcome should apply l2 branch transfer and fallback rules', as
 
     await engine.applyCombatOutcome({
         proxyId: proxy.id,
-        sourceName: 'battle-l2',
+        sourceName: 'battle-l3-browser',
         outcome: 'success',
         latencyMs: 20,
         nowIso: '2026-03-14T10:00:00.000Z',
-        stage: '评分(L2)',
+        stage: '评分(L3)',
         combatStage: 'l2',
+        branchingStage: 'l3',
     });
     const promoted = h.db.getProxyById(proxy.id);
     assert.equal(promoted.service_branch, '海军');
@@ -2863,21 +3268,23 @@ test('applyCombatOutcome should apply l2 branch transfer and fallback rules', as
 
     await engine.applyCombatOutcome({
         proxyId: proxy.id,
-        sourceName: 'battle-l2',
+        sourceName: 'battle-l3-browser',
         outcome: 'network_error',
         latencyMs: 0,
         nowIso: '2026-03-14T10:10:00.000Z',
-        stage: '评分(L2)',
+        stage: '评分(L3)',
         combatStage: 'l2',
+        branchingStage: 'l3',
     });
     await engine.applyCombatOutcome({
         proxyId: proxy.id,
-        sourceName: 'battle-l2',
+        sourceName: 'battle-l3-browser',
         outcome: 'network_error',
         latencyMs: 0,
         nowIso: '2026-03-14T10:20:00.000Z',
-        stage: '评分(L2)',
+        stage: '评分(L3)',
         combatStage: 'l2',
+        branchingStage: 'l3',
     });
     const beforeFallback = h.db.getProxyById(proxy.id);
     assert.equal(beforeFallback.service_branch, '海军');
@@ -2885,12 +3292,13 @@ test('applyCombatOutcome should apply l2 branch transfer and fallback rules', as
 
     await engine.applyCombatOutcome({
         proxyId: proxy.id,
-        sourceName: 'battle-l2',
+        sourceName: 'battle-l3-browser',
         outcome: 'network_error',
         latencyMs: 0,
         nowIso: '2026-03-14T10:30:00.000Z',
-        stage: '评分(L2)',
+        stage: '评分(L3)',
         combatStage: 'l2',
+        branchingStage: 'l3',
     });
     const fallenBack = h.db.getProxyById(proxy.id);
     assert.equal(fallenBack.service_branch, '陆军');
@@ -2901,7 +3309,7 @@ test('applyCombatOutcome should apply l2 branch transfer and fallback rules', as
     cleanupDb(h);
 });
 
-test('applyCombatOutcome should score L3 with L2 weight while applying L3 branch transition', async () => {
+test('applyCombatOutcome should score L3 with L2 weight while applying L3 branch transition to navy', async () => {
     const h = createDbHandle();
     const logger = createLogger();
     const now = '2026-03-14T11:00:00.000Z';
@@ -2948,7 +3356,7 @@ test('applyCombatOutcome should score L3 with L2 weight while applying L3 branch
 
     const updated = h.db.getProxyById(proxy.id);
     assert.equal(updated.combat_points, 12);
-    assert.equal(updated.service_branch, '海豹突击队');
+    assert.equal(updated.service_branch, '海军');
     assert.equal(h.db.getEvents(20).some((item) => item.event_type === 'branch_transfer'), true);
     cleanupDb(h);
 });

--- a/apps/proxy-pool-service/src/server.test.js
+++ b/apps/proxy-pool-service/src/server.test.js
@@ -149,6 +149,8 @@ function createStubs() {
             l2_fail_count: 1,
             l3_success_count: 2,
             l3_fail_count: 1,
+            l4_success_count: 1,
+            l4_fail_count: 0,
         }],
         getRankBoard: () => [{ rank: '新兵', count: 1 }],
         getServiceBranchDistribution: () => [{ service_branch: '陆军', count: 1 }],
@@ -326,6 +328,8 @@ test('server runtime should expose all REST endpoints and shutdown cleanly', asy
     assert.equal(typeof valueBoardPayload.items[0].l2_fail_count, 'number');
     assert.equal(typeof valueBoardPayload.items[0].l3_success_count, 'number');
     assert.equal(typeof valueBoardPayload.items[0].l3_fail_count, 'number');
+    assert.equal(typeof valueBoardPayload.items[0].l4_success_count, 'number');
+    assert.equal(typeof valueBoardPayload.items[0].l4_fail_count, 'number');
     assert.equal(typeof valueBoardPayload.items[0].native_place, 'string');
     assert.equal(typeof valueBoardPayload.items[0].native_lookup_raw_json, 'string');
     assert.equal(typeof valueBoardPayload.items[0].native_lookup_readable_text, 'string');

--- a/apps/proxy-pool-service/src/views.test.js
+++ b/apps/proxy-pool-service/src/views.test.js
@@ -48,19 +48,22 @@ test('renderProxyAdminPage should inject refresh interval', () => {
     assert.equal(html.includes("原始JSON"), false);
     assert.equal(html.includes("'<td title=\"' + esc(nativeTip) + '\">' + esc(nativePlace) + '</td>'"), true);
     assert.equal(html.includes("label: 'L0'"), true);
-    assert.equal(html.includes("label: 'L1'"), true);
-    assert.equal(html.includes("label: 'L2'"), true);
     assert.equal(html.includes("label: 'L3'"), true);
+    assert.equal(html.includes("label: 'L4'"), true);
+    assert.equal(html.includes("label: 'L1'"), false);
+    assert.equal(html.includes("label: 'L2'"), false);
     assert.equal(html.includes("help: 'L0'"), true);
-    assert.equal(html.includes("help: 'L1'"), true);
-    assert.equal(html.includes("help: 'L2'"), true);
     assert.equal(html.includes("help: 'L3'"), true);
+    assert.equal(html.includes("help: 'L4'"), true);
+    assert.equal(html.includes("help: 'L1'"), false);
+    assert.equal(html.includes("help: 'L2'"), false);
     assert.equal(html.includes('function fmtSuccessTotalPercent(success, total)'), true);
     assert.equal(html.includes("toFixed(1)"), true);
     assert.equal(html.includes("fmtSuccessTotalPercent(x.l0_success_count, l0Total)"), true);
-    assert.equal(html.includes("fmtSuccessTotalPercent(x.l1_success_count, l1Total)"), true);
-    assert.equal(html.includes("fmtSuccessTotalPercent(x.l2_success_count, l2Total)"), true);
     assert.equal(html.includes("fmtSuccessTotalPercent(x.l3_success_count, l3Total)"), true);
+    assert.equal(html.includes("fmtSuccessTotalPercent(x.l4_success_count, l4Total)"), true);
+    assert.equal(html.includes("fmtSuccessTotalPercent(x.l1_success_count, l1Total)"), false);
+    assert.equal(html.includes("fmtSuccessTotalPercent(x.l2_success_count, l2Total)"), false);
 });
 
 test('renderRuntimeLogsPage should return static html', () => {

--- a/apps/proxy-pool-service/src/views/proxy-admin.html
+++ b/apps/proxy-pool-service/src/views/proxy-admin.html
@@ -162,9 +162,8 @@ function getValueBoardHeaders(rankHelp) {
     { label: '成功率', help: '历史成功次数除以总样本数，反映总体能不能跑通。' },
     { label: '战场胜率', help: '战场测试里成功次数除以战场总次数，反映真实战场好不好用。' },
     { label: 'L0', help: 'L0' },
-    { label: 'L1', help: 'L1' },
-    { label: 'L2', help: 'L2' },
     { label: 'L3', help: 'L3' },
+    { label: 'L4', help: 'L4' },
     { label: '激活荣誉', help: '当前生效中的荣誉标签，代表这个IP最近在某些维度表现突出。' },
     { label: '地址', help: 'IP、端口和协议组合地址，排障和复现问题时最直接。' },
     { label: '来源', help: '这个IP来自哪个抓取源，可用来判断源质量。' },
@@ -260,9 +259,8 @@ function renderValueBoardTable() {
       ? '未知'
       : normalizeNativeTooltipText(sanitizeNativeReadableText(x.native_lookup_readable_text));
     const l0Total = Number(x.l0_success_count || 0) + Number(x.l0_fail_count || 0);
-    const l1Total = Number(x.l1_success_count || 0) + Number(x.l1_fail_count || 0);
-    const l2Total = Number(x.l2_success_count || 0) + Number(x.l2_fail_count || 0);
     const l3Total = Number(x.l3_success_count || 0) + Number(x.l3_fail_count || 0);
+    const l4Total = Number(x.l4_success_count || 0) + Number(x.l4_fail_count || 0);
     return ''
       + '<tr>'
       + '<td>' + entry.rank + '</td>'
@@ -275,9 +273,8 @@ function renderValueBoardTable() {
       + '<td>' + fmtPercent(x.success_ratio) + '</td>'
       + '<td>' + fmtPercent(x.battle_ratio) + '</td>'
       + '<td class="mono">' + fmtSuccessTotalPercent(x.l0_success_count, l0Total) + '</td>'
-      + '<td class="mono">' + fmtSuccessTotalPercent(x.l1_success_count, l1Total) + '</td>'
-      + '<td class="mono">' + fmtSuccessTotalPercent(x.l2_success_count, l2Total) + '</td>'
       + '<td class="mono">' + fmtSuccessTotalPercent(x.l3_success_count, l3Total) + '</td>'
+      + '<td class="mono">' + fmtSuccessTotalPercent(x.l4_success_count, l4Total) + '</td>'
       + '<td>' + esc(honorText) + '</td>'
       + '<td class="mono">' + esc(address) + '</td>'
       + '<td>' + esc(x.source) + '</td>'

--- a/apps/proxy-pool-service/src/worker.js
+++ b/apps/proxy-pool-service/src/worker.js
@@ -771,6 +771,15 @@ async function runBattleL3BrowserTask(payload, deps = {}) {
     };
 }
 
+// 0312_runBattleL4BrowserTask_执行战场L4浏览器实战逻辑
+async function runBattleL4BrowserTask(payload, deps = {}) {
+    const l3Result = await runBattleL3BrowserTask(payload, deps);
+    return {
+        ...l3Result,
+        stage: 'l4',
+    };
+}
+
 // 0158_handleTask_处理任务逻辑
 async function handleTask(type, payload, deps = {}) {
     if (type === 'fetch-source') {
@@ -790,6 +799,9 @@ async function handleTask(type, payload, deps = {}) {
     }
     if (type === 'battle-l3-browser') {
         return runBattleL3BrowserTask(payload, deps);
+    }
+    if (type === 'battle-l4-browser') {
+        return runBattleL4BrowserTask(payload, deps);
     }
     if (type === 'state-transition') {
         return stateTransitionTask(payload, deps);
@@ -841,6 +853,7 @@ module.exports = {
     isFallbackContentValid,
     runBattleL2Task,
     runBattleL3BrowserTask,
+    runBattleL4BrowserTask,
     handleTask,
     attachWorkerListener,
 };

--- a/apps/proxy-pool-service/src/worker.test.js
+++ b/apps/proxy-pool-service/src/worker.test.js
@@ -26,6 +26,7 @@ const {
     isFallbackContentValid,
     runBattleL2Task,
     runBattleL3BrowserTask,
+    runBattleL4BrowserTask,
     handleTask,
     attachWorkerListener,
 } = require('./worker');
@@ -901,6 +902,22 @@ test('battle L3 browser task should cover fallback branch paths', async () => {
     assert.equal(invalidTargetsType.reason, 'missing_targets');
 });
 
+test('battle L4 browser task should reuse browser checker but mark stage as l4', async () => {
+    const result = await runBattleL4BrowserTask({
+        proxy: { protocol: 'http', ip: '1.1.1.1', port: 80 },
+        targets: [{ name: 'ly-browser', url: 'https://www.ly.com/flights/home' }],
+        timeoutMs: 50,
+        allowedProtocols: ['http'],
+    }, {
+        launchBrowser: createFakeBrowserLauncher([
+            { statusCode: 200, body: 'ly browser content long enough for assert' },
+        ]),
+    });
+    assert.equal(result.stage, 'l4');
+    assert.equal(result.outcome, 'success');
+    assert.equal(result.runs[0].target, 'ly-browser');
+});
+
 test('stateTransitionTask should return ok', () => {
     assert.deepEqual(stateTransitionTask(), { ok: true });
 });
@@ -955,6 +972,17 @@ test('handleTask should dispatch all task types and throw on unknown type', asyn
         ]),
     });
     assert.equal(l3Result.stage, 'l3');
+
+    const l4Result = await handleTask('battle-l4-browser', {
+        proxy: { protocol: 'http', ip: '1.1.1.1', port: 80 },
+        targets: [{ name: 'ly', url: 'https://www.ly.com' }],
+        allowedProtocols: ['http'],
+    }, {
+        launchBrowser: createFakeBrowserLauncher([
+            { statusCode: 200, body: 'ly browser content long enough for assert' },
+        ]),
+    });
+    assert.equal(l4Result.stage, 'l4');
 
     const transResult = await handleTask('state-transition', {});
     assert.equal(transResult.ok, true);


### PR DESCRIPTION
## Summary\n- align proxy-hub flow with #106: keep L3 (baidu) as scoring stage and split ly.com browser test as L4 non-scoring branch stage\n- add service-branch transitions: L3 success -> 海军, L4 success -> 海豹突击队, with fallback logic on repeated failures\n- remove L1/L2 board display and add L4 visibility in admin UI/value board data\n- update worker/browser tasks, DB board query, and tests for L3/L4 separation\n\n## Test\n- npm run test:proxyhub:coverage\n  - pass: lines/statements/functions 100%\n  - pass: branches 98.14% (>= 98%)\n\nCloses #106